### PR TITLE
skal kunne vise innslag på at behandling er opprettet samt henlagt

### DIFF
--- a/src/frontend/App/typer/fagsak.ts
+++ b/src/frontend/App/typer/fagsak.ts
@@ -8,6 +8,7 @@ export enum Fagsystem {
 }
 
 export enum StegType {
+    OPPRETTET = 'OPPRETTET',
     FORMKRAV = 'FORMKRAV',
     VURDERING = 'VURDERING',
     BREV = 'BREV',
@@ -17,6 +18,7 @@ export enum StegType {
 }
 
 export const behandlingStegTilRekkefølge: Record<StegType, number> = {
+    OPPRETTET: 0,
     FORMKRAV: 1,
     VURDERING: 2,
     BREV: 3,
@@ -26,6 +28,7 @@ export const behandlingStegTilRekkefølge: Record<StegType, number> = {
 };
 
 export const behandlingStegTilTekst: Record<StegType, string> = {
+    OPPRETTET: 'Opprettet',
     FORMKRAV: 'Formkrav',
     VURDERING: 'Vurdering',
     BREV: 'Brev',
@@ -35,6 +38,7 @@ export const behandlingStegTilTekst: Record<StegType, string> = {
 };
 
 export const behandlingStegFullførtTilTekst: Record<StegType, string> = {
+    OPPRETTET: 'Behandling er opprettet',
     FORMKRAV: 'Formkrav er oppdatert',
     VURDERING: 'Vurdering er oppdatert',
     BREV: 'Brev er oppdatert',

--- a/src/frontend/Komponenter/Behandling/Henleggelse/HenleggModal.tsx
+++ b/src/frontend/Komponenter/Behandling/Henleggelse/HenleggModal.tsx
@@ -20,35 +20,35 @@ export const HenleggModal: FC<{ behandling: Behandling }> = ({ behandling }) => 
     const { axiosRequest, settToast } = useApp();
     const navigate = useNavigate();
     const [henlagtårsak, settHenlagtårsak] = useState<EHenlagtårsak>();
-    const [låsKnapp, settLåsKnapp] = useState<boolean>(false);
+    const [henleggerBehandling, settHenleggerBehandling] = useState<boolean>(false);
     const [feilmelding, settFeilmelding] = useState<string>();
 
-    const lagreHenleggelse = () => {
+    const henleggBehandling = () => {
+        if (henleggerBehandling) {
+            return;
+        }
         if (!henlagtårsak) {
             settFeilmelding('Du må velge en henleggelsesårsak');
         }
+        settHenleggerBehandling(true);
 
-        if (låsKnapp || !henlagtårsak) {
-            return;
-        }
-        settLåsKnapp(true);
         axiosRequest<string, { årsak: EHenlagtårsak }>({
             method: 'POST',
             url: `/familie-klage/api/behandling/${behandling.id}/henlegg`,
             data: {
-                årsak: henlagtårsak,
+                årsak: henlagtårsak as EHenlagtårsak,
             },
         })
             .then((respons: RessursSuksess<string> | RessursFeilet) => {
                 if (respons.status === RessursStatus.SUKSESS) {
-                    settVisHenleggModal(false);
+                    lukkModal();
                     navigate(`/behandling/${behandling.id}/resultat`);
                     settToast(EToast.BEHANDLING_HENLAGT);
                 } else {
                     settFeilmelding(respons.frontendFeilmelding);
                 }
             })
-            .finally(() => settLåsKnapp(false));
+            .finally(() => settHenleggerBehandling(false));
     };
 
     const lukkModal = () => {
@@ -63,9 +63,9 @@ export const HenleggModal: FC<{ behandling: Behandling }> = ({ behandling }) => 
             onClose={() => lukkModal()}
             aksjonsknapper={{
                 hovedKnapp: {
-                    onClick: () => lagreHenleggelse(),
+                    onClick: () => henleggBehandling(),
                     tekst: 'Henlegg',
-                    disabled: låsKnapp,
+                    disabled: henleggerBehandling,
                 },
                 lukkKnapp: { onClick: () => lukkModal(), tekst: 'Avbryt' },
             }}

--- a/src/frontend/Komponenter/Behandling/utils.ts
+++ b/src/frontend/Komponenter/Behandling/utils.ts
@@ -1,5 +1,5 @@
 import { Behandling, BehandlingResultat, StegType } from '../../App/typer/fagsak';
-import { utledTekstForEksternutfall } from './Resultat/utils';
+import { utledTekstForBehandlingsresultat } from './Resultat/utils';
 import { IVurdering, vedtakValgTilTekst } from './Vurdering/vurderingValg';
 
 export const utledStegutfallForIkkeFerdigstiltBehandling = (
@@ -28,7 +28,7 @@ export const utledStegutfallForFerdigstiltBehandling = (behandling: Behandling, 
                 ? 'Omgjør vedtak'
                 : 'Oppretthold vedtak';
         case StegType.BEHANDLING_FERDIGSTILT:
-            return utledTekstForEksternutfall(behandling);
+            return utledTekstForBehandlingsresultat(behandling);
         default:
             return '';
     }


### PR DESCRIPTION
Løser [dette kortet](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-9913)

(Får nå historikkinnslag på henlagt og behandling opprettet)

Backend må merges først:
* https://github.com/navikt/familie-klage/pull/129

Tidslinjevisning med behandling opprettet:
![Skjermbilde 2022-10-26 kl  15 15 37](https://user-images.githubusercontent.com/32769446/198035639-24621aca-4648-400f-9ad6-f5bee84490c3.png)

Høyremenyvisning med et innsalg av henlagt:
![Skjermbilde 2022-10-26 kl  15 15 42](https://user-images.githubusercontent.com/32769446/198035685-39c6e796-a939-4151-b352-0d1e88ee24fd.png)
