### PR TITLE
Skal kun vise utfall for hendelsen ferdigstilt behandling i historikken

### DIFF
--- a/src/frontend/Komponenter/Behandling/Formkrav/EndreFormkravVurderinger.tsx
+++ b/src/frontend/Komponenter/Behandling/Formkrav/EndreFormkravVurderinger.tsx
@@ -1,6 +1,5 @@
 import React, { Dispatch, SetStateAction, useState } from 'react';
 import {
-    FagsystemVedtak,
     IFormkravVilkår,
     IFormalkrav,
     Redigeringsmodus,
@@ -28,6 +27,7 @@ import {
     påKlagetVedtakValgt,
 } from './validerFormkravUtils';
 import { utledRadioKnapper } from './utils';
+import { FagsystemVedtak } from '../../../App/typer/fagsystemVedtak';
 
 const RadioGrupperContainer = styled.div`
     display: flex;

--- a/src/frontend/Komponenter/Behandling/Formkrav/Formkrav.tsx
+++ b/src/frontend/Komponenter/Behandling/Formkrav/Formkrav.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { KlageInfo } from './KlageInfo';
 import { RessursFeilet, RessursStatus, RessursSuksess } from '../../../App/typer/ressurs';
 import { useBehandling } from '../../../App/context/BehandlingContext';
-import { FagsystemVedtak, IFormkravVilkår } from './typer';
+import { IFormkravVilkår } from './typer';
 import ToKolonnerLayout from '../../../Felles/Visningskomponenter/ToKolonnerLayout';
 import { VisEllerEndreFormkravVurderinger } from './VisEllerEndreFormkravVurderinger';
 import DataViewer from '../../../Felles/DataViewer/DataViewer';
@@ -10,6 +10,7 @@ import { Behandling } from '../../../App/typer/fagsak';
 import { useHentFormkravVilkår } from '../../../App/hooks/useHentFormkravVilkår';
 import { utledRedigeringsmodus } from './validerFormkravUtils';
 import { useHentFagsystemVedtak } from '../../../App/hooks/useHentFagsystemVedtak';
+import { FagsystemVedtak } from '../../../App/typer/fagsystemVedtak';
 
 export const Formkrav: React.FC<{ behandling: Behandling }> = ({ behandling }) => {
     const { vilkårsvurderinger, hentVilkårsvurderinger, lagreVilkårsvurderinger, feilVedLagring } =

--- a/src/frontend/Komponenter/Behandling/Formkrav/VedtakSelect.tsx
+++ b/src/frontend/Komponenter/Behandling/Formkrav/VedtakSelect.tsx
@@ -1,9 +1,10 @@
 import React, { Dispatch, SetStateAction } from 'react';
 import styled from 'styled-components';
-import { FagsystemVedtak, IFormkravVilkår } from './typer';
+import { IFormkravVilkår } from './typer';
 import { PåklagetVedtakstype, påklagetVedtakstypeTilTekst } from '../../../App/typer/fagsak';
 import { FamilieSelect } from '@navikt/familie-form-elements';
 import { erVedtak, fagsystemVedtakTilVisningstekst, sorterVedtakstidspunktDesc } from './utils';
+import { FagsystemVedtak } from '../../../App/typer/fagsystemVedtak';
 
 interface IProps {
     settOppdaterteVurderinger: Dispatch<SetStateAction<IFormkravVilkår>>;

--- a/src/frontend/Komponenter/Behandling/Formkrav/VisEllerEndreFormkravVurderinger.tsx
+++ b/src/frontend/Komponenter/Behandling/Formkrav/VisEllerEndreFormkravVurderinger.tsx
@@ -1,8 +1,9 @@
 import React, { Dispatch, SetStateAction } from 'react';
 import { VisFormkravVurderinger } from './VisFormkravVurderinger';
-import { FagsystemVedtak, IFormkravVilkår, Redigeringsmodus } from './typer';
+import { IFormkravVilkår, Redigeringsmodus } from './typer';
 import { EndreFormkravVurderinger } from './EndreFormkravVurderinger';
 import { RessursFeilet, RessursSuksess } from '../../../App/typer/ressurs';
+import { FagsystemVedtak } from '../../../App/typer/fagsystemVedtak';
 
 export interface IProps {
     vurderinger: IFormkravVilkår;

--- a/src/frontend/Komponenter/Behandling/Formkrav/VisFormkravVurderinger.tsx
+++ b/src/frontend/Komponenter/Behandling/Formkrav/VisFormkravVurderinger.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 import { NavdsGlobalColorPurple500 } from '@navikt/ds-tokens/dist/tokens';
 import BrukerMedBlyant from '../../../Felles/Ikoner/BrukerMedBlyant';
 import {
-    FagsystemVedtak,
     IFormkravVilkår,
     IFormalkrav,
     Redigeringsmodus,
@@ -29,6 +28,7 @@ import {
     påKlagetVedtakValgt,
     utledIkkeUtfylteVilkår,
 } from './validerFormkravUtils';
+import { FagsystemVedtak } from '../../../App/typer/fagsystemVedtak';
 
 export const RadSentrertVertikalt = styled.div`
     display: flex;

--- a/src/frontend/Komponenter/Behandling/Formkrav/utils.ts
+++ b/src/frontend/Komponenter/Behandling/Formkrav/utils.ts
@@ -1,13 +1,8 @@
-import {
-    EFormalKravType,
-    FagsystemType,
-    FagsystemVedtak,
-    IFormkravVilkår,
-    IFormalkrav,
-} from './typer';
+import { EFormalKravType, FagsystemType, IFormkravVilkår, IFormalkrav } from './typer';
 import { PåklagetVedtak, PåklagetVedtakstype } from '../../../App/typer/fagsak';
 import { compareDesc } from 'date-fns';
 import { formaterIsoDato, formaterIsoDatoTid } from '../../../App/utils/formatter';
+import { FagsystemVedtak } from '../../../App/typer/fagsystemVedtak';
 
 export const utledRadioKnapper = (vurderinger: IFormkravVilkår): IFormalkrav[] => {
     const { klagePart, klageKonkret, klagefristOverholdt, klageSignert } = vurderinger;

--- a/src/frontend/Komponenter/Behandling/Høyremeny/Historikk.tsx
+++ b/src/frontend/Komponenter/Behandling/Høyremeny/Historikk.tsx
@@ -25,12 +25,9 @@ const HistorikkContainer: React.FC<{
     behandling: Behandling;
     behandlingHistorikk: IBehandlingshistorikk[];
 }> = ({ behandling, behandlingHistorikk }) => {
-    const steg = behandlingHistorikk.map((historikk) => historikk.steg);
-
     return (
         <>
             {behandlingHistorikk.map((historikk, index) => {
-                const erSisteForekomstAvStegtype = steg.indexOf(historikk.steg) === index;
                 return (
                     <HistorikkInnslag
                         behandling={behandling}
@@ -38,7 +35,6 @@ const HistorikkContainer: React.FC<{
                         opprettetAv={historikk.opprettetAv}
                         endretTid={historikk.endretTid}
                         key={index}
-                        visStegutfall={erSisteForekomstAvStegtype}
                     />
                 );
             })}

--- a/src/frontend/Komponenter/Behandling/Høyremeny/HistorikkInnslag.tsx
+++ b/src/frontend/Komponenter/Behandling/Høyremeny/HistorikkInnslag.tsx
@@ -3,18 +3,9 @@ import { NavdsSemanticColorBorder } from '@navikt/ds-tokens/dist/tokens';
 import { BodyShort, Detail, Label } from '@navikt/ds-react';
 import styled from 'styled-components';
 import { formaterIsoDatoTid } from '../../../App/utils/formatter';
-import {
-    Behandling,
-    BehandlingResultat,
-    behandlingStegFullførtTilTekst,
-    StegType,
-} from '../../../App/typer/fagsak';
+import { Behandling, behandlingStegFullførtTilTekst, StegType } from '../../../App/typer/fagsak';
 import { PeopleInCircle } from '@navikt/ds-icons';
-import {
-    utledStegutfallForFerdigstiltBehandling,
-    utledStegutfallForIkkeFerdigstiltBehandling,
-} from '../utils';
-import { useBehandling } from '../../../App/context/BehandlingContext';
+import { utledStegutfallForFerdigstiltBehandling } from '../utils';
 
 const Innslag = styled.div`
     display: flex;
@@ -41,7 +32,6 @@ interface IHistorikkOppdatering {
     steg: StegType;
     opprettetAv: string;
     endretTid: string;
-    visStegutfall: boolean;
 }
 
 const HistorikkInnslag: React.FunctionComponent<IHistorikkOppdatering> = ({
@@ -49,16 +39,7 @@ const HistorikkInnslag: React.FunctionComponent<IHistorikkOppdatering> = ({
     steg,
     opprettetAv,
     endretTid,
-    visStegutfall,
 }) => {
-    const { formkravOppfylt, oppdatertVurdering } = useBehandling();
-
-    const utledStegutfall = (behandling: Behandling) => {
-        return behandling.resultat === BehandlingResultat.IKKE_SATT
-            ? utledStegutfallForIkkeFerdigstiltBehandling(steg, formkravOppfylt, oppdatertVurdering)
-            : utledStegutfallForFerdigstiltBehandling(behandling, steg);
-    };
-
     return (
         <Innslag>
             <Ikon>
@@ -67,7 +48,11 @@ const HistorikkInnslag: React.FunctionComponent<IHistorikkOppdatering> = ({
             </Ikon>
             <Tekst>
                 <Label size="small">{behandlingStegFullførtTilTekst[steg]}</Label>
-                {visStegutfall && <BodyShort>{utledStegutfall(behandling)}</BodyShort>}
+                {steg === StegType.BEHANDLING_FERDIGSTILT && (
+                    <BodyShort>
+                        {utledStegutfallForFerdigstiltBehandling(behandling, steg)}
+                    </BodyShort>
+                )}
                 <Detail size="small">
                     {formaterIsoDatoTid(endretTid)} | {opprettetAv}
                 </Detail>

--- a/src/frontend/Komponenter/Behandling/utils.ts
+++ b/src/frontend/Komponenter/Behandling/utils.ts
@@ -4,24 +4,12 @@ import {
     behandlingResultatTilTekst,
     StegType,
 } from '../../App/typer/fagsak';
-import { IVurdering, vedtakValgTilTekst } from './Vurdering/vurderingValg';
 import { utledTekstForEksternutfall } from './Resultat/utils';
 
-export const utledStegutfallForIkkeFerdigstiltBehandling = (
-    steg: StegType,
-    formKravOppfylt: boolean,
-    vurdering: IVurdering
-) => {
-    switch (steg) {
-        case StegType.FORMKRAV:
-            return formKravOppfylt ? 'Oppfylt' : 'Ikke oppfylt';
-        case StegType.VURDERING:
-            return vurdering.vedtak ? vedtakValgTilTekst[vurdering.vedtak] : '';
-        default:
-            return '';
-    }
-};
-
+/**
+ * Forenklet utledning av stegutfall
+ * Denne skal ikke brukes for formkrav eller vurdering hvis resultat = Henlagt
+ */
 export const utledStegutfallForFerdigstiltBehandling = (behandling: Behandling, steg: StegType) => {
     switch (steg) {
         case StegType.FORMKRAV:


### PR DESCRIPTION
- Dette då vi kanskje ikke har en vurdering å sjekke resultatet fra hvis man endret formkravet eller henlagt

Ytterligare forbedring fra tidligere PR's
Det kan bli vist feil resultat på formkrav/vurdering hvis man eks henlagt eller endret formkravet og då ikke har en vurdering noe lengre. 

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10449

![image](https://user-images.githubusercontent.com/937168/205292256-a0fb806a-98ed-4dd5-a737-573ecdd1bf7f.png)
![image](https://user-images.githubusercontent.com/937168/205292304-fb3f9893-3739-40ec-85f6-5d00e26c5b3d.png)

