### PR TITLE
Opprett revurdering automatisk info

### DIFF
--- a/src/frontend/App/typer/kanOppretteRevurdering.ts
+++ b/src/frontend/App/typer/kanOppretteRevurdering.ts
@@ -1,0 +1,10 @@
+export type KanOppretteRevurdering =
+    | {
+          kanOpprettes: true;
+      }
+    | { kanOpprettes: false; årsak?: KanIkkeOppretteRevurderingÅrsak };
+
+export enum KanIkkeOppretteRevurderingÅrsak {
+    ÅPEN_BEHANDLING = 'ÅPEN_BEHANDLING',
+    INGEN_BEHANDLING = 'INGEN_BEHANDLING',
+}

--- a/src/frontend/App/typer/ressurs.ts
+++ b/src/frontend/App/typer/ressurs.ts
@@ -66,7 +66,7 @@ export const harNoenRessursMedStatus = (
     ...status: RessursStatus[]
 ): boolean => ressurser.some((ressurs) => status.includes(ressurs.status));
 
-export const erAvTypeFeil = <T>(data: Ressurs<T>): boolean =>
+export const erAvTypeFeil = <T>(data: Ressurs<T>): data is RessursFeilet =>
     [RessursStatus.FEILET, RessursStatus.FUNKSJONELL_FEIL, RessursStatus.IKKE_TILGANG].includes(
         data.status
     );

--- a/src/frontend/Komponenter/Behandling/Brev/Brev.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Brev.tsx
@@ -17,6 +17,11 @@ import PdfVisning from './PdfVisning';
 import { ModalWrapper } from '../../../Felles/Modal/ModalWrapper';
 import SystemetLaster from '../../../Felles/SystemetLaster/SystemetLaster';
 import BrevMottakere from '../Brevmottakere/BrevMottakere';
+import {
+    KanIkkeOppretteRevurderingÅrsak,
+    KanOppretteRevurdering,
+} from '../../../App/typer/kanOppretteRevurdering';
+import DataViewer from '../../../Felles/DataViewer/DataViewer';
 
 const Brevside = styled.div`
     background-color: var(--navds-semantic-color-canvas-background);
@@ -54,6 +59,106 @@ type Utfall = 'IKKE_SATT' | 'LAG_BREV' | 'OMGJØR_VEDTAK';
 interface IBrev {
     behandlingId: string;
 }
+
+const KanOppretteRevurderingTekst: React.FC<{ kanOppretteRevurdering: KanOppretteRevurdering }> = ({
+    kanOppretteRevurdering,
+}) => {
+    if (kanOppretteRevurdering.kanOpprettes) {
+        return (
+            <Alert variant={'info'}>
+                Resultatet av klagebehandlingen er at påklaget vedtak skal omgjøres. Du kan nå
+                ferdigstille klagebehandlingen og en revurderingsbehandling for å fatte nytt vedtak
+                blir automatisk opprettet.
+            </Alert>
+        );
+    } else if (kanOppretteRevurdering.årsak === KanIkkeOppretteRevurderingÅrsak.ÅPEN_BEHANDLING) {
+        return (
+            <Alert variant={'warning'}>
+                Resultatet av klagebehandlingen er at påklaget vedtak skal omgjøres. En
+                revurderingsbehandling for å fatte nytt vedtak blir ikke automatisk opprettet da
+                bruker allerede har en åpen behandling.
+            </Alert>
+        );
+    } else {
+        return (
+            <Alert variant={'warning'}>
+                Resultatet av klagebehandlingen er at påklaget vedtak skal omgjøres. En
+                revurderingsbehandling for å fatte nytt vedtak blir ikke automatisk opprettet.
+            </Alert>
+        );
+    }
+};
+
+export const OmgjørVedtak: React.FC<{
+    behandlingId: string;
+    ferdigstill: () => void;
+    senderInn: boolean;
+}> = ({ behandlingId, ferdigstill, senderInn }) => {
+    const { axiosRequest } = useApp();
+    const { behandlingErRedigerbar } = useBehandling();
+    const [visModal, settVisModal] = useState<boolean>(false);
+    const [feilmelding, settFeilmelding] = useState('');
+    const [kanOppretteRevurdering, settKanOppretteRevurdering] = useState<
+        Ressurs<KanOppretteRevurdering>
+    >(byggTomRessurs());
+
+    const lukkModal = () => {
+        settVisModal(false);
+        settFeilmelding('');
+    };
+
+    useEffect(() => {
+        if (behandlingErRedigerbar) {
+            axiosRequest<KanOppretteRevurdering, null>({
+                method: 'GET',
+                url: `/familie-klage/api/behandling/${behandlingId}/kan-opprette-revurdering`,
+            }).then(settKanOppretteRevurdering);
+        }
+    }, [axiosRequest, behandlingErRedigerbar, behandlingId]);
+
+    return (
+        <DataViewer response={{ kanOppretteRevurdering }}>
+            {({ kanOppretteRevurdering }) => (
+                <>
+                    {behandlingErRedigerbar && (
+                        <AlertContainer>
+                            <KanOppretteRevurderingTekst
+                                kanOppretteRevurdering={kanOppretteRevurdering}
+                            />
+                            <StyledKnapp onClick={() => settVisModal(true)}>
+                                Ferdigstill
+                            </StyledKnapp>
+                        </AlertContainer>
+                    )}
+                    {!behandlingErRedigerbar && (
+                        <AlertContainer>
+                            <Alert variant={'info'}>
+                                Brev finnes ikke fordi klagen er tatt til følge.
+                            </Alert>
+                        </AlertContainer>
+                    )}
+                    <ModalWrapper
+                        tittel={'Bekreft ferdigstillelse av klagebehandling'}
+                        visModal={visModal}
+                        onClose={() => lukkModal()}
+                        aksjonsknapper={{
+                            hovedKnapp: {
+                                onClick: ferdigstill,
+                                tekst: 'Ferdigstill',
+                                disabled: senderInn,
+                            },
+                            lukkKnapp: { onClick: lukkModal, tekst: 'Avbryt' },
+                            marginTop: 4,
+                        }}
+                    >
+                        {feilmelding && <AlertStripe variant={'error'}>{feilmelding}</AlertStripe>}
+                    </ModalWrapper>
+                </>
+            )}
+        </DataViewer>
+    );
+};
+
 export const Brev: React.FC<IBrev> = ({ behandlingId }) => {
     const [brevRessurs, settBrevRessurs] = useState<Ressurs<string>>(byggTomRessurs());
 
@@ -187,41 +292,11 @@ export const Brev: React.FC<IBrev> = ({ behandlingId }) => {
         );
     } else if (utfall === 'OMGJØR_VEDTAK') {
         return (
-            <>
-                {behandlingErRedigerbar && (
-                    <AlertContainer>
-                        <Alert variant={'info'}>
-                            Resultatet av klagebehandlingen er at påklaget vedtak skal omgjøres. Du
-                            kan nå ferdigstille klagebehandlingen og en revurderingsbehandling for å
-                            fatte nytt vedtak blir automatisk opprettet.
-                        </Alert>
-                        <StyledKnapp onClick={() => settVisModal(true)}>Ferdigstill</StyledKnapp>
-                    </AlertContainer>
-                )}
-                {!behandlingErRedigerbar && (
-                    <AlertContainer>
-                        <Alert variant={'info'}>
-                            Brev finnes ikke fordi klagen er tatt til følge.
-                        </Alert>
-                    </AlertContainer>
-                )}
-                <ModalWrapper
-                    tittel={'Bekreft ferdigstillelse av klagebehandling'}
-                    visModal={visModal}
-                    onClose={() => lukkModal()}
-                    aksjonsknapper={{
-                        hovedKnapp: {
-                            onClick: ferdigstill,
-                            tekst: 'Ferdigstill',
-                            disabled: senderInn,
-                        },
-                        lukkKnapp: { onClick: lukkModal, tekst: 'Avbryt' },
-                        marginTop: 4,
-                    }}
-                >
-                    {feilmelding && <AlertStripe variant={'error'}>{feilmelding}</AlertStripe>}
-                </ModalWrapper>
-            </>
+            <OmgjørVedtak
+                behandlingId={behandlingId}
+                ferdigstill={ferdigstill}
+                senderInn={senderInn}
+            />
         );
     } else {
         return <div>{feilmelding || <SystemetLaster />}</div>;

--- a/src/frontend/Komponenter/Behandling/Brev/Brev.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Brev.tsx
@@ -17,11 +17,7 @@ import PdfVisning from './PdfVisning';
 import { ModalWrapper } from '../../../Felles/Modal/ModalWrapper';
 import SystemetLaster from '../../../Felles/SystemetLaster/SystemetLaster';
 import BrevMottakere from '../Brevmottakere/BrevMottakere';
-import {
-    KanIkkeOppretteRevurderingÅrsak,
-    KanOppretteRevurdering,
-} from '../../../App/typer/kanOppretteRevurdering';
-import DataViewer from '../../../Felles/DataViewer/DataViewer';
+import { OmgjørVedtak } from './OmgjørVedtak';
 
 const Brevside = styled.div`
     background-color: var(--navds-semantic-color-canvas-background);
@@ -45,11 +41,6 @@ const AlertStripe = styled(Alert)`
     margin-top: 2rem;
 `;
 
-const AlertContainer = styled.div`
-    padding: 2rem;
-    max-width: 40rem;
-`;
-
 const StyledKnapp = styled(Button)`
     margin-top: 2rem;
 `;
@@ -59,105 +50,6 @@ type Utfall = 'IKKE_SATT' | 'LAG_BREV' | 'OMGJØR_VEDTAK';
 interface IBrev {
     behandlingId: string;
 }
-
-const KanOppretteRevurderingTekst: React.FC<{ kanOppretteRevurdering: KanOppretteRevurdering }> = ({
-    kanOppretteRevurdering,
-}) => {
-    if (kanOppretteRevurdering.kanOpprettes) {
-        return (
-            <Alert variant={'info'}>
-                Resultatet av klagebehandlingen er at påklaget vedtak skal omgjøres. Du kan nå
-                ferdigstille klagebehandlingen og en revurderingsbehandling for å fatte nytt vedtak
-                blir automatisk opprettet.
-            </Alert>
-        );
-    } else if (kanOppretteRevurdering.årsak === KanIkkeOppretteRevurderingÅrsak.ÅPEN_BEHANDLING) {
-        return (
-            <Alert variant={'warning'}>
-                Resultatet av klagebehandlingen er at påklaget vedtak skal omgjøres. En
-                revurderingsbehandling for å fatte nytt vedtak blir ikke automatisk opprettet da
-                bruker allerede har en åpen behandling.
-            </Alert>
-        );
-    } else {
-        return (
-            <Alert variant={'warning'}>
-                Resultatet av klagebehandlingen er at påklaget vedtak skal omgjøres. En
-                revurderingsbehandling for å fatte nytt vedtak blir ikke automatisk opprettet.
-            </Alert>
-        );
-    }
-};
-
-export const OmgjørVedtak: React.FC<{
-    behandlingId: string;
-    ferdigstill: () => void;
-    senderInn: boolean;
-}> = ({ behandlingId, ferdigstill, senderInn }) => {
-    const { axiosRequest } = useApp();
-    const { behandlingErRedigerbar } = useBehandling();
-    const [visModal, settVisModal] = useState<boolean>(false);
-    const [feilmelding, settFeilmelding] = useState('');
-    const [kanOppretteRevurdering, settKanOppretteRevurdering] = useState<
-        Ressurs<KanOppretteRevurdering>
-    >(byggTomRessurs());
-
-    const lukkModal = () => {
-        settVisModal(false);
-        settFeilmelding('');
-    };
-
-    useEffect(() => {
-        if (behandlingErRedigerbar) {
-            axiosRequest<KanOppretteRevurdering, null>({
-                method: 'GET',
-                url: `/familie-klage/api/behandling/${behandlingId}/kan-opprette-revurdering`,
-            }).then(settKanOppretteRevurdering);
-        }
-    }, [axiosRequest, behandlingErRedigerbar, behandlingId]);
-
-    return (
-        <DataViewer response={{ kanOppretteRevurdering }}>
-            {({ kanOppretteRevurdering }) => (
-                <>
-                    {behandlingErRedigerbar && (
-                        <AlertContainer>
-                            <KanOppretteRevurderingTekst
-                                kanOppretteRevurdering={kanOppretteRevurdering}
-                            />
-                            <StyledKnapp onClick={() => settVisModal(true)}>
-                                Ferdigstill
-                            </StyledKnapp>
-                        </AlertContainer>
-                    )}
-                    {!behandlingErRedigerbar && (
-                        <AlertContainer>
-                            <Alert variant={'info'}>
-                                Brev finnes ikke fordi klagen er tatt til følge.
-                            </Alert>
-                        </AlertContainer>
-                    )}
-                    <ModalWrapper
-                        tittel={'Bekreft ferdigstillelse av klagebehandling'}
-                        visModal={visModal}
-                        onClose={() => lukkModal()}
-                        aksjonsknapper={{
-                            hovedKnapp: {
-                                onClick: ferdigstill,
-                                tekst: 'Ferdigstill',
-                                disabled: senderInn,
-                            },
-                            lukkKnapp: { onClick: lukkModal, tekst: 'Avbryt' },
-                            marginTop: 4,
-                        }}
-                    >
-                        {feilmelding && <AlertStripe variant={'error'}>{feilmelding}</AlertStripe>}
-                    </ModalWrapper>
-                </>
-            )}
-        </DataViewer>
-    );
-};
 
 export const Brev: React.FC<IBrev> = ({ behandlingId }) => {
     const [brevRessurs, settBrevRessurs] = useState<Ressurs<string>>(byggTomRessurs());

--- a/src/frontend/Komponenter/Behandling/Brev/OmgjørVedtak.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/OmgjørVedtak.tsx
@@ -1,0 +1,125 @@
+import * as React from 'react';
+import {
+    KanIkkeOppretteRevurderingÅrsak,
+    KanOppretteRevurdering,
+} from '../../../App/typer/kanOppretteRevurdering';
+import { Alert, Button } from '@navikt/ds-react';
+import { useApp } from '../../../App/context/AppContext';
+import { useBehandling } from '../../../App/context/BehandlingContext';
+import { useEffect, useState } from 'react';
+import { byggTomRessurs, Ressurs } from '../../../App/typer/ressurs';
+import DataViewer from '../../../Felles/DataViewer/DataViewer';
+import { ModalWrapper } from '../../../Felles/Modal/ModalWrapper';
+import styled from 'styled-components';
+
+const AlertContainer = styled.div`
+    padding: 2rem;
+    max-width: 40rem;
+`;
+
+const AlertStripe = styled(Alert)`
+    margin-top: 2rem;
+`;
+
+const StyledKnapp = styled(Button)`
+    margin-top: 2rem;
+`;
+
+const KanOppretteRevurderingTekst: React.FC<{ kanOppretteRevurdering: KanOppretteRevurdering }> = ({
+    kanOppretteRevurdering,
+}) => {
+    if (kanOppretteRevurdering.kanOpprettes) {
+        return (
+            <Alert variant={'info'}>
+                Resultatet av klagebehandlingen er at påklaget vedtak skal omgjøres. Du kan nå
+                ferdigstille klagebehandlingen og en revurderingsbehandling for å fatte nytt vedtak
+                blir automatisk opprettet.
+            </Alert>
+        );
+    } else if (kanOppretteRevurdering.årsak === KanIkkeOppretteRevurderingÅrsak.ÅPEN_BEHANDLING) {
+        return (
+            <Alert variant={'warning'}>
+                Resultatet av klagebehandlingen er at påklaget vedtak skal omgjøres. En
+                revurderingsbehandling for å fatte nytt vedtak blir ikke automatisk opprettet da
+                bruker allerede har en åpen behandling.
+            </Alert>
+        );
+    } else {
+        return (
+            <Alert variant={'warning'}>
+                Resultatet av klagebehandlingen er at påklaget vedtak skal omgjøres. En
+                revurderingsbehandling for å fatte nytt vedtak blir ikke automatisk opprettet.
+            </Alert>
+        );
+    }
+};
+
+export const OmgjørVedtak: React.FC<{
+    behandlingId: string;
+    ferdigstill: () => void;
+    senderInn: boolean;
+}> = ({ behandlingId, ferdigstill, senderInn }) => {
+    const { axiosRequest } = useApp();
+    const { behandlingErRedigerbar } = useBehandling();
+    const [visModal, settVisModal] = useState<boolean>(false);
+    const [feilmelding, settFeilmelding] = useState('');
+    const [kanOppretteRevurdering, settKanOppretteRevurdering] = useState<
+        Ressurs<KanOppretteRevurdering>
+    >(byggTomRessurs());
+
+    const lukkModal = () => {
+        settVisModal(false);
+        settFeilmelding('');
+    };
+
+    useEffect(() => {
+        if (behandlingErRedigerbar) {
+            axiosRequest<KanOppretteRevurdering, null>({
+                method: 'GET',
+                url: `/familie-klage/api/behandling/${behandlingId}/kan-opprette-revurdering`,
+            }).then(settKanOppretteRevurdering);
+        }
+    }, [axiosRequest, behandlingErRedigerbar, behandlingId]);
+
+    return (
+        <DataViewer response={{ kanOppretteRevurdering }}>
+            {({ kanOppretteRevurdering }) => (
+                <>
+                    {behandlingErRedigerbar && (
+                        <AlertContainer>
+                            <KanOppretteRevurderingTekst
+                                kanOppretteRevurdering={kanOppretteRevurdering}
+                            />
+                            <StyledKnapp onClick={() => settVisModal(true)}>
+                                Ferdigstill
+                            </StyledKnapp>
+                        </AlertContainer>
+                    )}
+                    {!behandlingErRedigerbar && (
+                        <AlertContainer>
+                            <Alert variant={'info'}>
+                                Brev finnes ikke fordi klagen er tatt til følge.
+                            </Alert>
+                        </AlertContainer>
+                    )}
+                    <ModalWrapper
+                        tittel={'Bekreft ferdigstillelse av klagebehandling'}
+                        visModal={visModal}
+                        onClose={() => lukkModal()}
+                        aksjonsknapper={{
+                            hovedKnapp: {
+                                onClick: ferdigstill,
+                                tekst: 'Ferdigstill',
+                                disabled: senderInn,
+                            },
+                            lukkKnapp: { onClick: lukkModal, tekst: 'Avbryt' },
+                            marginTop: 4,
+                        }}
+                    >
+                        {feilmelding && <AlertStripe variant={'error'}>{feilmelding}</AlertStripe>}
+                    </ModalWrapper>
+                </>
+            )}
+        </DataViewer>
+    );
+};

--- a/src/frontend/Komponenter/Behandling/Brev/OmgjørVedtak.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/OmgjørVedtak.tsx
@@ -81,6 +81,13 @@ export const OmgjørVedtak: React.FC<{
         }
     }, [axiosRequest, behandlingErRedigerbar, behandlingId]);
 
+    if (!behandlingErRedigerbar) {
+        return (
+            <AlertContainer>
+                <Alert variant={'info'}>Brev finnes ikke fordi klagen er tatt til følge.</Alert>
+            </AlertContainer>
+        );
+    }
     return (
         <DataViewer response={{ kanOppretteRevurdering }}>
             {({ kanOppretteRevurdering }) => (
@@ -93,13 +100,6 @@ export const OmgjørVedtak: React.FC<{
                             <StyledKnapp onClick={() => settVisModal(true)}>
                                 Ferdigstill
                             </StyledKnapp>
-                        </AlertContainer>
-                    )}
-                    {!behandlingErRedigerbar && (
-                        <AlertContainer>
-                            <Alert variant={'info'}>
-                                Brev finnes ikke fordi klagen er tatt til følge.
-                            </Alert>
                         </AlertContainer>
                     )}
                     <ModalWrapper


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10275

Det er ønskelig å vise en info-tekst når man klikker på ferdigstill som sier om en ny behandling kan opprettes eller ikke (se skisser)

* https://github.com/navikt/familie-klage/pull/214
* https://github.com/navikt/familie-ef-sak/pull/1963