### PR TITLE
Fikser tekster for automatisk opprettelse av revurdering

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/OmgjørVedtak.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/OmgjørVedtak.tsx
@@ -33,17 +33,17 @@ const KanOppretteRevurderingTekst: React.FC<{ kanOppretteRevurdering: KanOpprett
     if (kanOppretteRevurdering.kanOpprettes) {
         return (
             <Alert variant={'info'}>
-                Resultatet av klagebehandlingen er at påklaget vedtak skal omgjøres. Du kan nå
-                ferdigstille klagebehandlingen og en revurderingsbehandling for å fatte nytt vedtak
-                blir automatisk opprettet.
+                Resultatet av klagebehandlingen er at påklaget vedtak skal omgjøres. Når du
+                ferdigstiller klagebehandlingen vil det automatisk bli opprettet en
+                revurderingsbehandling.
             </Alert>
         );
     } else if (kanOppretteRevurdering.årsak === KanIkkeOppretteRevurderingÅrsak.ÅPEN_BEHANDLING) {
         return (
             <Alert variant={'warning'}>
-                Resultatet av klagebehandlingen er at påklaget vedtak skal omgjøres. En
-                revurderingsbehandling for å fatte nytt vedtak blir ikke automatisk opprettet da
-                bruker allerede har en åpen behandling.
+                Resultatet av klagebehandlingen er at påklaget vedtak skal omgjøres. Det vil ikke
+                bli opprettet en revurderingsbehandling automatisk fordi det allerede finnes en åpen
+                behandling på bruker.
             </Alert>
         );
     } else {

--- a/src/frontend/Komponenter/Behandling/Resultat/Tidslinje.tsx
+++ b/src/frontend/Komponenter/Behandling/Resultat/Tidslinje.tsx
@@ -228,13 +228,13 @@ export const MedholdRevurdering: React.FC<{
         return (
             <>
                 <WarningColored width={36} height={36} />
+                <Label size={'small'}>Må manuelt opprettes</Label>
                 {fagsystemRevurdering && (
                     <Detail size="small">
                         Årsak:{' '}
                         {revurderingIkkeOpprettetÅrsak[fagsystemRevurdering.ikkeOpprettet.årsak]}
                     </Detail>
                 )}
-                <Label size={'small'}>Må manuellt opprettes</Label>
                 <Button
                     as={'a'}
                     variant={'secondary'}


### PR DESCRIPTION
Flytter opp label over detail i resultat


Siste fiks på denne?  https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10275
<img width="260" alt="image" src="https://user-images.githubusercontent.com/937168/207835290-7bfa5469-d13a-47b1-9b1e-7ef751e57201.png">
