### PR TITLE
Låser brevfanen for henlagte behandlinger

### DIFF
--- a/src/frontend/Komponenter/Behandling/Fanemeny/Fanemeny.tsx
+++ b/src/frontend/Komponenter/Behandling/Fanemeny/Fanemeny.tsx
@@ -4,7 +4,12 @@ import styled from 'styled-components';
 import { alleSider, ISide, SideNavn } from './sider';
 import { Sticky } from '../../../Felles/Visningskomponenter/Sticky';
 import Fane from './Fane';
-import { Behandling, behandlingStegTilRekkefølge, StegType } from '../../../App/typer/fagsak';
+import {
+    Behandling,
+    BehandlingResultat,
+    behandlingStegTilRekkefølge,
+    StegType,
+} from '../../../App/typer/fagsak';
 import { useBehandling } from '../../../App/context/BehandlingContext';
 import { NavdsGlobalColorWhite, NavdsSemanticColorBorder } from '@navikt/ds-tokens/dist/tokens';
 
@@ -31,6 +36,9 @@ const Fanemeny: FC<Props> = ({ behandling }) => {
     const faneErLåst = (side: ISide, steg: StegType): boolean => {
         if (side.navn === SideNavn.VURDERING) {
             return !formkravOppfylt;
+        }
+        if (side.navn === SideNavn.BREV && behandling.resultat === BehandlingResultat.HENLAGT) {
+            return true;
         }
         return side.rekkefølge > behandlingStegTilRekkefølge[steg];
     };

--- a/src/frontend/Komponenter/Behandling/Henleggelse/HenleggModal.tsx
+++ b/src/frontend/Komponenter/Behandling/Henleggelse/HenleggModal.tsx
@@ -15,7 +15,8 @@ const AlertStripe = styled(Alert)`
 `;
 
 export const HenleggModal: FC<{ behandling: Behandling }> = ({ behandling }) => {
-    const { visHenleggModal, settVisHenleggModal } = useBehandling();
+    const { visHenleggModal, settVisHenleggModal, hentBehandling, hentBehandlingshistorikk } =
+        useBehandling();
 
     const { axiosRequest, settToast } = useApp();
     const navigate = useNavigate();
@@ -42,6 +43,8 @@ export const HenleggModal: FC<{ behandling: Behandling }> = ({ behandling }) => 
             .then((respons: RessursSuksess<string> | RessursFeilet) => {
                 if (respons.status === RessursStatus.SUKSESS) {
                     lukkModal();
+                    hentBehandling.rerun();
+                    hentBehandlingshistorikk.rerun();
                     navigate(`/behandling/${behandling.id}/resultat`);
                     settToast(EToast.BEHANDLING_HENLAGT);
                 } else {


### PR DESCRIPTION
Laster behandling og behandlingshistorikk ved henleggelse for att resultatet skal vises riktig på resultatsiden, og historikken

https://nav-it.slack.com/archives/G012YEK9YQ1/p1671109217274759