### PR TITLE
skal ikke kunne henlegge klagebehandling uten å velge årsak

### DIFF
--- a/src/frontend/Komponenter/Behandling/Henleggelse/HenleggModal.tsx
+++ b/src/frontend/Komponenter/Behandling/Henleggelse/HenleggModal.tsx
@@ -30,6 +30,7 @@ export const HenleggModal: FC<{ behandling: Behandling }> = ({ behandling }) => 
         }
         if (!henlagtårsak) {
             settFeilmelding('Du må velge en henleggelsesårsak');
+            return;
         }
         settHenleggerBehandling(true);
 


### PR DESCRIPTION
**Hvorfor?**
Oppdaget at vi ikke har noen sjekk på om man har valgt årsak for henleggelse i henleggelsesmodalen. Denne PRen gjør slik at man ikke får sendt request til backend uten å ha valgt årsak først.

Tidligere fikk man en feilmelding fra backend istedet, så det har ikke kommet gjennom noen henleggelser uten årsak til databasen.