### PR TITLE
Trenger behandlingId i SøkPerson komponent for å søke etter person

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brevmottakere/BrevmottakereModal.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/BrevmottakereModal.tsx
@@ -120,6 +120,7 @@ export const BrevmottakereModal: FC<{
                         settValgtePersonMottakere={settValgtePersonMottakere}
                         valgteOrganisasjonMottakere={valgteOrganisasjonMottakere}
                         settValgteOrganisasjonMottakere={settValgteOrganisasjonMottakere}
+                        behandlingId={behandlingId}
                     />
                     <HorisontalLinje />
                     <SkalBrukerHaBrev

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/SøkPerson.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/SøkPerson.tsx
@@ -6,34 +6,36 @@ import { EBrevmottakerRolle, IBrevmottaker } from './typer';
 import { BodyShort, Button } from '@navikt/ds-react';
 import { Søkefelt, Søkeresultat } from './brevmottakereStyling';
 import { VertikalSentrering } from '../../../App/utils/styling';
-
 interface Props {
     settValgteMottakere: Dispatch<SetStateAction<IBrevmottaker[]>>;
+    behandlingId: string;
 }
 
 interface PersonSøk {
     personIdent: string;
+    behandlingId: string;
     navn: string;
 }
 
-export const SøkPerson: React.FC<Props> = ({ settValgteMottakere }) => {
+export const SøkPerson: React.FC<Props> = ({ settValgteMottakere, behandlingId }) => {
     const { axiosRequest } = useApp();
     const [søkIdent, settSøkIdent] = useState('');
     const [søkRessurs, settSøkRessurs] = useState(byggTomRessurs<PersonSøk>());
 
     useEffect(() => {
         if (søkIdent && søkIdent.length === 11) {
-            axiosRequest<PersonSøk, { personIdent: string }>({
+            axiosRequest<PersonSøk, { personIdent: string; behandlingId: string }>({
                 method: 'POST',
                 url: 'familie-klage/api/sok/person',
                 data: {
                     personIdent: søkIdent,
+                    behandlingId: behandlingId,
                 },
             }).then((resp: Ressurs<PersonSøk>) => {
                 settSøkRessurs(resp);
             });
         }
-    }, [axiosRequest, søkIdent]);
+    }, [axiosRequest, søkIdent, behandlingId]);
 
     const leggTilBrevmottaker = (personIdent: string, navn: string) => () => {
         settValgteMottakere((prevState) => [

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/SøkWrapper.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/SøkWrapper.tsx
@@ -9,6 +9,7 @@ interface Props {
     settValgtePersonMottakere: Dispatch<SetStateAction<IBrevmottaker[]>>;
     valgteOrganisasjonMottakere: IOrganisasjonMottaker[];
     settValgteOrganisasjonMottakere: Dispatch<SetStateAction<IOrganisasjonMottaker[]>>;
+    behandlingId: string;
 }
 
 enum ESøktype {
@@ -29,6 +30,7 @@ export const SøkWrapper: FC<Props> = ({
     settValgtePersonMottakere,
     valgteOrganisasjonMottakere,
     settValgteOrganisasjonMottakere,
+    behandlingId,
 }) => {
     const [søktype, settSøktype] = useState<ESøktype>();
 
@@ -52,7 +54,10 @@ export const SøkWrapper: FC<Props> = ({
                 />
             )}
             {søktype === ESøktype.PERSON && (
-                <SøkPerson settValgteMottakere={settValgtePersonMottakere} />
+                <SøkPerson
+                    settValgteMottakere={settValgtePersonMottakere}
+                    behandlingId={behandlingId}
+                />
             )}
         </>
     );


### PR DESCRIPTION
Hvorfor ? 

PDL klienten i backend bruker stønadstype for å utlede tema og behandlingsnummer, og derfor må behandlingId sendes til backend. 

Se : https://github.com/navikt/familie-klage/pull/306

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12402