### PR TITLE
Skal vise info om feilregistrert behandling

### DIFF
--- a/src/frontend/App/typer/fagsak.ts
+++ b/src/frontend/App/typer/fagsak.ts
@@ -105,6 +105,7 @@ export interface KlageinstansResultat {
     utfall?: KlageinstansUtfall;
     mottattEllerAvsluttetTidspunkt: string;
     journalpostReferanser: string[];
+    årsakFeilregistrert?: string;
 }
 
 export enum KlageinstansEventType {
@@ -112,6 +113,7 @@ export enum KlageinstansEventType {
     ANKEBEHANDLING_OPPRETTET = 'ANKEBEHANDLING_OPPRETTET',
     ANKEBEHANDLING_AVSLUTTET = 'ANKEBEHANDLING_AVSLUTTET',
     ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET = 'ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET',
+    BEHANDLING_FEILREGISTRERT = 'BEHANDLING_FEILREGISTRERT',
 }
 
 export const klagehendelseTypeTilTekst: Record<KlageinstansEventType, string> = {
@@ -119,6 +121,7 @@ export const klagehendelseTypeTilTekst: Record<KlageinstansEventType, string> = 
     ANKEBEHANDLING_OPPRETTET: 'Ankebehandling opprettet',
     ANKEBEHANDLING_AVSLUTTET: 'Ankebehandling avsluttet',
     ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET: 'Anke i trygderettenbehandling opprettet',
+    BEHANDLING_FEILREGISTRERT: 'Behandling feilregistrert',
 };
 
 export enum KlageinstansUtfall {

--- a/src/frontend/Komponenter/Behandling/Resultat/AnkeVisning.tsx
+++ b/src/frontend/Komponenter/Behandling/Resultat/AnkeVisning.tsx
@@ -20,8 +20,12 @@ const Container = styled.div`
 `;
 
 export const AnkeVisning: React.FC<{ behandling: Behandling }> = ({ behandling }) => {
-    const ankeResultater = behandling.klageinstansResultat.filter(
-        (resultat) => resultat.type != KlageinstansEventType.KLAGEBEHANDLING_AVSLUTTET
+    const ankeResultater = behandling.klageinstansResultat.filter((resultat) =>
+        [
+            KlageinstansEventType.ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET,
+            KlageinstansEventType.ANKEBEHANDLING_OPPRETTET,
+            KlageinstansEventType.ANKEBEHANDLING_AVSLUTTET,
+        ].includes(resultat.type)
     );
 
     return (

--- a/src/frontend/Komponenter/Behandling/Resultat/FeilregistrertVisning.tsx
+++ b/src/frontend/Komponenter/Behandling/Resultat/FeilregistrertVisning.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { Behandling, KlageinstansEventType } from '../../../App/typer/fagsak';
+import { Alert, BodyShort, Heading, Label } from '@navikt/ds-react';
+import styled from 'styled-components';
+import { formaterIsoDatoTid } from '../../../App/utils/formatter';
+
+const AlerMedMaxbredde = styled(Alert)`
+    max-width: 60rem;
+`;
+
+export const FeilregistrertVisning: React.FC<{ behandling: Behandling }> = ({ behandling }) => {
+    const feilregistrertResultat = behandling.klageinstansResultat.find(
+        (resultat) => resultat.type === KlageinstansEventType.BEHANDLING_FEILREGISTRERT
+    );
+
+    return feilregistrertResultat ? (
+        <AlerMedMaxbredde variant={'warning'}>
+            <Heading spacing size="small" level="3">
+                Behandling feilregistrert av NAV klageinstans
+            </Heading>
+            <Label size={'small'}>
+                {formaterIsoDatoTid(feilregistrertResultat.mottattEllerAvsluttetTidspunkt)}
+            </Label>
+            <BodyShort>{feilregistrertResultat.årsakFeilregistrert}</BodyShort>
+        </AlerMedMaxbredde>
+    ) : null;
+};

--- a/src/frontend/Komponenter/Behandling/Resultat/Resultat.tsx
+++ b/src/frontend/Komponenter/Behandling/Resultat/Resultat.tsx
@@ -6,6 +6,7 @@ import DataViewer from '../../../Felles/DataViewer/DataViewer';
 import { Heading } from '@navikt/ds-react';
 import { useBehandling } from '../../../App/context/BehandlingContext';
 import { AnkeVisning } from './AnkeVisning';
+import { FeilregistrertVisning } from './FeilregistrertVisning';
 
 const HeadingContainer = styled.div`
     margin: 2rem 5rem 0rem 5rem;
@@ -36,6 +37,7 @@ export const Resultat: React.FC = () => {
                         <Heading spacing size="large" level="5">
                             Resultat
                         </Heading>
+                        <FeilregistrertVisning behandling={behandling} />
                     </HeadingContainer>
                     <TidslinjeContainer åpenHøyremeny={åpenHøyremeny}>
                         <Tidslinje

--- a/src/frontend/Komponenter/Behandling/Resultat/utils.ts
+++ b/src/frontend/Komponenter/Behandling/Resultat/utils.ts
@@ -1,7 +1,12 @@
 import { IBehandlingshistorikk } from '../Høyremeny/behandlingshistorikk';
 import { ensure } from '../../../App/utils/utils';
-import { KlageinstansEventType, utfallTilTekst } from '../../../App/typer/fagsak';
-import { Behandling, behandlingResultatTilTekst, StegType } from '../../../App/typer/fagsak';
+import {
+    Behandling,
+    behandlingResultatTilTekst,
+    KlageinstansEventType,
+    StegType,
+    utfallTilTekst,
+} from '../../../App/typer/fagsak';
 
 export const fjernDuplikatStegFraHistorikk = (steg: IBehandlingshistorikk[]) => {
     const visning = [
@@ -24,6 +29,14 @@ export const fjernDuplikatStegFraHistorikk = (steg: IBehandlingshistorikk[]) => 
 };
 
 export const utledTekstForEksternutfall = (behandling: Behandling) => {
+    const erFeilregistrert = behandling.klageinstansResultat.some(
+        (resultat) => resultat.type === KlageinstansEventType.BEHANDLING_FEILREGISTRERT
+    );
+
+    if (erFeilregistrert) {
+        return 'Behandling feilregistrert';
+    }
+
     const klageResultatMedUtfall = behandling.klageinstansResultat.filter(
         (resultat) =>
             resultat.utfall && resultat.type == KlageinstansEventType.KLAGEBEHANDLING_AVSLUTTET


### PR DESCRIPTION
### Hvorfor?
Når en behandling er feilregistrert i kabal blir denne ferdigstilt hos oss. Vi må derfor vise begrunnelse og tidspunkt for feilregistrering.

### Bilder 🎥
![image](https://github.com/navikt/familie-klage-frontend/assets/21220467/e99fd69d-f9dc-4461-8231-da693f8c88b5)
![image](https://github.com/navikt/familie-klage-frontend/assets/21220467/c6e4d5ee-e290-4ad7-b7f8-ff05cee7c86b)


