### PR TITLE
Forbedring av ankevisning på resultatside

### DIFF
--- a/src/frontend/Komponenter/Behandling/Resultat/AnkeVisning.tsx
+++ b/src/frontend/Komponenter/Behandling/Resultat/AnkeVisning.tsx
@@ -5,18 +5,12 @@ import {
     KlageinstansEventType,
     utfallTilTekst,
 } from '../../../App/typer/fagsak';
-import { BodyShort, Label } from '@navikt/ds-react';
+import { Alert, BodyShort, Heading, Label } from '@navikt/ds-react';
 import styled from 'styled-components';
 import { formaterIsoDatoTid } from '../../../App/utils/formatter';
 
-const StyledAnkeInfo = styled.div`
-    display: grid;
-    grid-template-columns: 12rem 8.5rem 10rem;
-    align-items: center;
-`;
-
-const Container = styled.div`
-    margin: 2rem 1rem 1rem 1rem;
+const AlerMedMaxbredde = styled(Alert)`
+    max-width: 60rem;
 `;
 
 export const AnkeVisning: React.FC<{ behandling: Behandling }> = ({ behandling }) => {
@@ -28,21 +22,22 @@ export const AnkeVisning: React.FC<{ behandling: Behandling }> = ({ behandling }
         ].includes(resultat.type)
     );
 
-    return (
-        <Container>
+    return ankeResultater.length > 0 ? (
+        <AlerMedMaxbredde variant={'warning'}>
+            <Heading spacing size="small" level="3">
+                Merk at det finnes informasjon om anke på denne klagen
+            </Heading>
             {ankeResultater.map((resultat) => (
-                <StyledAnkeInfo key={resultat.mottattEllerAvsluttetTidspunkt}>
-                    <div>
-                        <Label size={'small'}>{klagehendelseTypeTilTekst[resultat.type]}</Label>:
-                    </div>
-                    <BodyShort size={'small'}>
+                <div key={resultat.mottattEllerAvsluttetTidspunkt}>
+                    <Label size={'small'}>
                         {formaterIsoDatoTid(resultat.mottattEllerAvsluttetTidspunkt)}
-                    </BodyShort>
-                    <BodyShort size={'small'}>
-                        {resultat.utfall && utfallTilTekst[resultat.utfall]}
-                    </BodyShort>
-                </StyledAnkeInfo>
+                    </Label>
+                    <BodyShort size={'small'}>{klagehendelseTypeTilTekst[resultat.type]}</BodyShort>
+                    {resultat.utfall && (
+                        <BodyShort size={'small'}>{utfallTilTekst[resultat.utfall]}</BodyShort>
+                    )}
+                </div>
             ))}
-        </Container>
-    );
+        </AlerMedMaxbredde>
+    ) : null;
 };

--- a/src/frontend/Komponenter/Behandling/Resultat/Resultat.tsx
+++ b/src/frontend/Komponenter/Behandling/Resultat/Resultat.tsx
@@ -38,6 +38,7 @@ export const Resultat: React.FC = () => {
                             Resultat
                         </Heading>
                         <FeilregistrertVisning behandling={behandling} />
+                        <AnkeVisning behandling={behandling} />
                     </HeadingContainer>
                     <TidslinjeContainer åpenHøyremeny={åpenHøyremeny}>
                         <Tidslinje
@@ -45,7 +46,6 @@ export const Resultat: React.FC = () => {
                             behandlingHistorikk={behandlingHistorikk}
                             åpenHøyremeny={åpenHøyremeny}
                         />
-                        <AnkeVisning behandling={behandling} />
                     </TidslinjeContainer>
                 </>
             )}


### PR DESCRIPTION
**Hvorfor?**
Det skal tydelig fremgå på resultatsiden at det finnes informasjon om anke

[Nederste punktet i favrokort](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-13830)

#### Bilder
**Før**
<img width="1781" alt="image" src="https://github.com/navikt/familie-klage-frontend/assets/21220467/397dc569-66ae-4317-b0d0-5bf084003932">

**Etter**
<img width="1785" alt="image" src="https://github.com/navikt/familie-klage-frontend/assets/21220467/a37aca73-71aa-42c2-8637-6256160980bc">
