### PR TITLE
Refaktorert dokumentliste

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@navikt/ds-css": "6.11.x",
     "@navikt/ds-react": "6.11.x",
     "@navikt/familie-backend": "^10.0.20",
-    "@navikt/familie-dokumentliste": "^12.0.0",
     "@navikt/familie-endringslogg": "^12.0.2",
     "@navikt/familie-form-elements": "^15.0.0",
     "@navikt/familie-header": "^14.0.3",

--- a/src/frontend/Komponenter/Behandling/Høyremeny/Dokumenter.tsx
+++ b/src/frontend/Komponenter/Behandling/Høyremeny/Dokumenter.tsx
@@ -4,13 +4,13 @@ import { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { IBehandlingParams } from '../../../App/typer/routing';
 import { useDataHenter } from '../../../App/hooks/felles/useDataHenter';
-import { Dokumentliste, DokumentProps } from '@navikt/familie-dokumentliste';
 import DataViewer from '../../../Felles/DataViewer/DataViewer';
 import { compareDesc } from 'date-fns';
 import { formaterNullableIsoDatoTid } from '../../../App/utils/formatter';
 import { Heading } from '@navikt/ds-react';
 import { åpneFilIEgenTab } from '../../../App/utils/utils';
 import styled from 'styled-components';
+import Dokumentliste, { DokumentProps } from './Dokumentliste';
 
 const OverSkrift = styled(Heading)`
     margin-top: 0.5rem;

--- a/src/frontend/Komponenter/Behandling/Høyremeny/Dokumentliste.tsx
+++ b/src/frontend/Komponenter/Behandling/Høyremeny/Dokumentliste.tsx
@@ -1,0 +1,104 @@
+import * as React from 'react';
+import styled from 'styled-components';
+import { ILogiskVedlegg, Journalposttype } from '@navikt/familie-typer';
+import { BodyShort, Button, Tag } from '@navikt/ds-react';
+import { LogiskeVedlegg } from './LogiskeVedlegg';
+
+const StyledDokumentListe = styled.ul`
+    padding: 0;
+    margin: 0 1rem;
+    list-style-type: none;
+    span {
+        font-weight: var(--a-font-weight-regular);
+    }
+`;
+
+const StyledLi = styled.li`
+    display: grid;
+    grid-template-columns: repeat(2, minmax(2rem, max-content));
+    gap: 0.5rem;
+    margin: 0.5rem 0;
+`;
+
+const StyledButton = styled(Button)`
+    margin: 0;
+    padding: 0;
+    text-align: left;
+`;
+
+interface JournalpostTagProps {
+    journalposttype: Journalposttype;
+}
+
+const JournalpostTag: React.FC<JournalpostTagProps> = ({ journalposttype }) => {
+    switch (journalposttype) {
+        case 'I':
+            return (
+                <Tag variant="info-moderate" size="small">
+                    I
+                </Tag>
+            );
+        case 'N':
+            return (
+                <Tag variant="neutral-moderate" size="small">
+                    N
+                </Tag>
+            );
+        case 'U':
+            return (
+                <Tag variant="alt1-moderate" size="small">
+                    U
+                </Tag>
+            );
+    }
+};
+
+export interface DokumentProps {
+    tittel: string;
+    dato?: string;
+    journalpostId: string;
+    journalposttype: Journalposttype;
+    dokumentinfoId: string;
+    filnavn?: string;
+    logiskeVedlegg?: ILogiskVedlegg[];
+}
+
+export interface DokumentElementProps {
+    dokument: DokumentProps;
+    onClick: (dokument: DokumentProps) => void;
+}
+
+export interface DokumentlisteProps {
+    dokumenter: DokumentProps[];
+    onClick: (dokument: DokumentProps) => void;
+    className?: string;
+}
+
+export const DokumentElement: React.FC<DokumentElementProps> = ({ dokument, onClick }) => {
+    return (
+        <StyledLi>
+            <div>
+                <JournalpostTag journalposttype={dokument.journalposttype} />
+            </div>
+            <div>
+                <StyledButton variant="tertiary" size="small" onClick={() => onClick(dokument)}>
+                    {dokument.tittel}
+                </StyledButton>
+                <BodyShort size="small">{dokument.dato}</BodyShort>
+                <LogiskeVedlegg logiskeVedlegg={dokument.logiskeVedlegg} />
+            </div>
+        </StyledLi>
+    );
+};
+
+export const Dokumentliste: React.FC<DokumentlisteProps> = ({ dokumenter, onClick, className }) => {
+    return (
+        <StyledDokumentListe className={className}>
+            {dokumenter.map((dokument: DokumentProps, indeks: number) => {
+                return <DokumentElement dokument={dokument} onClick={onClick} key={indeks} />;
+            })}
+        </StyledDokumentListe>
+    );
+};
+
+export default Dokumentliste;

--- a/src/frontend/Komponenter/Behandling/Høyremeny/LogiskeVedlegg.tsx
+++ b/src/frontend/Komponenter/Behandling/Høyremeny/LogiskeVedlegg.tsx
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+import * as React from 'react';
+import { ILogiskVedlegg } from '@navikt/familie-typer';
+import { Detail } from '@navikt/ds-react';
+
+const LogiskVedleggWrapper = styled.ul`
+    list-style-type: circle;
+`;
+
+export const LogiskeVedlegg: React.FC<{ logiskeVedlegg: ILogiskVedlegg[] | undefined }> = ({
+    logiskeVedlegg,
+}) => (
+    <LogiskVedleggWrapper>
+        {logiskeVedlegg &&
+            logiskeVedlegg.map((logiskVedlegg, index) => (
+                <li key={logiskVedlegg.tittel + index}>
+                    <Detail>{logiskVedlegg.tittel}</Detail>
+                </li>
+            ))}
+    </LogiskVedleggWrapper>
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1539,14 +1539,6 @@
     prom-client "^15.1.0"
     redis "^4.6.13"
 
-"@navikt/familie-dokumentliste@^12.0.0":
-  version "12.0.0"
-  resolved "https://npm.pkg.github.com/download/@navikt/familie-dokumentliste/12.0.0/48a391b8365dd40b6abaee4124f7588e4bff0ca1#48a391b8365dd40b6abaee4124f7588e4bff0ca1"
-  integrity sha512-OMan+enwh+vbyUJ6hPXueuRpCAAHsd9SNsiEOSyLAL8i+HAUuAcR07elZ05wg9gjq4Ehj7MnH+zydGTIg8530A==
-  dependencies:
-    "@navikt/familie-ikoner" "^9.0.1"
-    "@navikt/familie-typer" "^8.0.2"
-
 "@navikt/familie-endringslogg@^12.0.2":
   version "12.0.2"
   resolved "https://npm.pkg.github.com/download/@navikt/familie-endringslogg/12.0.2/4036173993d27265340ae9febbc0a4205b992b73#4036173993d27265340ae9febbc0a4205b992b73"


### PR DESCRIPTION
* Fjernet avhengigheten familie-dokumentliste. 
* Flyttet kode fra familie-felles-frontend. 
* Refaktorert Dokumentliste til å bruke tag med bokstaver i stedet for piler.

Bildet viser nytt design:
![image](https://github.com/navikt/familie-klage-frontend/assets/141132903/c6004e61-25bd-4b5e-a98d-b133943f3cbe)
