### PR TITLE
Gjemt SettPåVentKnapp bak feature toggle.

### DIFF
--- a/src/frontend/App/context/toggles.ts
+++ b/src/frontend/App/context/toggles.ts
@@ -4,4 +4,7 @@ export interface Toggles {
 
 export enum ToggleName {
     skalKunneVelgePåklagetVedtakFraInfotrygd = 'familie.klage.infotrygd-vedtak',
+
+    // Release-toggles
+    visSettPåVent = 'familie.klage.sett-pa-vent',
 }

--- a/src/frontend/Felles/Visittkort/HenleggKnapp.tsx
+++ b/src/frontend/Felles/Visittkort/HenleggKnapp.tsx
@@ -2,11 +2,16 @@ import React from 'react';
 import { useBehandling } from '../../App/context/BehandlingContext';
 import { Button } from '@navikt/ds-react';
 
-export const Henlegg = () => {
-    const { settVisHenleggModal } = useBehandling();
+export const HenleggKnapp = () => {
+    const { settVisHenleggModal, behandlingErRedigerbar } = useBehandling();
 
     return (
-        <Button onClick={() => settVisHenleggModal(true)} size="xsmall" variant="secondary">
+        <Button
+            disabled={!behandlingErRedigerbar}
+            onClick={() => settVisHenleggModal(true)}
+            size="xsmall"
+            variant="secondary"
+        >
             Henlegg
         </Button>
     );

--- a/src/frontend/Felles/Visittkort/SettPåVentKnapp.tsx
+++ b/src/frontend/Felles/Visittkort/SettPåVentKnapp.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Button } from '@navikt/ds-react';
+import { useToggles } from '../../App/context/TogglesContext';
+import { ToggleName } from '../../App/context/toggles';
+
+export const SettPåVentKnapp = () => {
+    const { toggles } = useToggles();
+
+    const visSettPåVent = toggles[ToggleName.visSettPåVent];
+
+    if (!visSettPåVent) {
+        return null;
+    }
+
+    return (
+        <Button size="xsmall" variant="secondary">
+            Sett på vent
+        </Button>
+    );
+};

--- a/src/frontend/Felles/Visittkort/Visittkort.tsx
+++ b/src/frontend/Felles/Visittkort/Visittkort.tsx
@@ -10,8 +10,7 @@ import {
 } from '../../App/typer/fagsak';
 import { ABorderStrong } from '@navikt/ds-tokens/dist/tokens';
 import { Sticky } from '../Visningskomponenter/Sticky';
-import { Henlegg } from './HenleggKnapp';
-import { erBehandlingRedigerbar } from '../../App/typer/behandlingstatus';
+import { HenleggKnapp } from './HenleggKnapp';
 import { Label, Link } from '@navikt/ds-react';
 import PersonStatusVarsel from '../Varsel/PersonStatusVarsel';
 import AdressebeskyttelseVarsel from '../Varsel/AdressebeskyttelseVarsel';
@@ -26,6 +25,7 @@ import {
 } from '../../App/utils/utils';
 import { useApp } from '../../App/context/AppContext';
 import { FagsystemType } from '../../Komponenter/Behandling/Formkrav/typer';
+import { SettPåVentKnapp } from './SettPåVentKnapp';
 
 const Visningsnavn = styled.div`
     text-overflow: ellipsis;
@@ -84,7 +84,6 @@ const VisittkortComponent: FC<{
     const behandlingLenke = utledBehandlingLenke(behandling, appEnv.eksternlenker);
     const saksoversiktLenke = utledSaksoversiktLenke(behandling, appEnv.eksternlenker);
     const tilbakekrevingLenke = utledTilbakekrevingLenke(behandling, appEnv.eksternlenker);
-    const behandlingErRedigerbar = erBehandlingRedigerbar(behandling);
 
     return (
         <Container>
@@ -162,8 +161,8 @@ const VisittkortComponent: FC<{
                                 </EtikettInfo>
                             )}
                         </TagsKnyttetTilBehandling>
-
-                        {behandlingErRedigerbar && <Henlegg />}
+                        <SettPåVentKnapp />
+                        <HenleggKnapp />
                     </>
                 )}
             </HøyreWrapper>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/26060925-027d-49d6-b7ea-56e52f0f43ea)

Klage ønsker å gjøre det mulig å sette klagebehandling på vent. Før vi introduserer innholdet, kan det være lurt å feature toggle dette. Denne PRen gjemmer en sett på vent knapp bak feature toggle. Denne funksjonaliteten depender på denne [PRen](https://github.com/navikt/familie-klage-frontend/pull/862) i `ef-klage` som introduserer selve togglene. 