### PR TITLE
Mappevelger bruker nå riktig "mappe" label

### DIFF
--- a/src/frontend/Komponenter/Behandling/SettPåVent/MappeVelger.tsx
+++ b/src/frontend/Komponenter/Behandling/SettPåVent/MappeVelger.tsx
@@ -55,7 +55,7 @@ export const MappeVelger: FC<{
                     <Select
                         disabled={!oppgaveEnhet || !visMapper(fagsystem)}
                         value={valgtMappe}
-                        label="IMappe"
+                        label="Mappe"
                         size="small"
                         readOnly={erLesevisning}
                         onChange={(e) => {


### PR DESCRIPTION
Liten korreksjon av label til `MappeVelger` grunnet renaming/refactoring. 

Vi går nå fra `IMappe` til `Mappe` i `MappeVelger` label. 