### PR TITLE
NAV-23444: Kobler sammen baks sin BrevmottakerContainer til Brev

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/Brev.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Brev.tsx
@@ -10,7 +10,7 @@ import {
 import { useBehandling } from '../../../App/context/BehandlingContext';
 import styled from 'styled-components';
 import { useApp } from '../../../App/context/AppContext';
-import { Alert, Button } from '@navikt/ds-react';
+import { Alert, Button, HGrid, VStack } from '@navikt/ds-react';
 import { useNavigate } from 'react-router-dom';
 import { IVurdering, VedtakValg } from '../Vurdering/vurderingValg';
 import PdfVisning from './PdfVisning';
@@ -18,40 +18,25 @@ import { ModalWrapper } from '../../../Felles/Modal/ModalWrapper';
 import SystemetLaster from '../../../Felles/SystemetLaster/SystemetLaster';
 import BrevMottakere from '../Brevmottakere/ef/BrevMottakere';
 import { OmgjørVedtak } from './OmgjørVedtak';
+import { BrevmottakerContainer as BaksBrevmottakerContainer } from '../Brevmottakere/baks/BrevmottakerContainer';
+import { Behandling, Fagsystem } from '../../../App/typer/fagsak';
 
 const Brevside = styled.div`
     background-color: var(--a-bg-subtle);
     padding: 2rem 2rem 0 2rem;
 `;
 
-const BrevContainer = styled.div`
-    display: grid;
-    grid-template-columns: 1fr 4fr;
-    grid-gap: 1rem;
-    justify-content: space-between;
-
-    @media only screen and (max-width: 1800px) {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 3rem;
-    }
-`;
-
 const AlertStripe = styled(Alert)`
-    margin-top: 2rem;
-`;
-
-const StyledKnapp = styled(Button)`
     margin-top: 2rem;
 `;
 
 type Utfall = 'IKKE_SATT' | 'LAG_BREV' | 'OMGJØR_VEDTAK';
 
-interface IBrev {
-    behandlingId: string;
-}
+type Props = {
+    behandling: Behandling;
+};
 
-export const Brev: React.FC<IBrev> = ({ behandlingId }) => {
+export const Brev: React.FC<Props> = ({ behandling }: Props) => {
     const [brevRessurs, settBrevRessurs] = useState<Ressurs<string>>(byggTomRessurs());
 
     const { hentBehandling, hentBehandlingshistorikk, behandlingErRedigerbar } = useBehandling();
@@ -63,6 +48,8 @@ export const Brev: React.FC<IBrev> = ({ behandlingId }) => {
     const [feilmelding, settFeilmelding] = useState('');
 
     const [utfall, settUtfall] = useState<Utfall>('IKKE_SATT');
+
+    const behandlingId = behandling.id;
 
     const hentVurdering = useCallback(
         (behandlingId: string) => {
@@ -147,25 +134,26 @@ export const Brev: React.FC<IBrev> = ({ behandlingId }) => {
     if (utfall === 'LAG_BREV') {
         return (
             <Brevside>
-                <BrevContainer>
-                    <div>
-                        {brevRessurs.status === RessursStatus.SUKSESS && (
-                            <BrevMottakere behandlingId={behandlingId} />
-                        )}
+                <HGrid gap={'6'} columns={{ xl: 1, '2xl': '1fr 1.2fr' }}>
+                    <VStack gap={'6'}>
+                        {brevRessurs.status === RessursStatus.SUKSESS &&
+                            (behandling.fagsystem === Fagsystem.EF ? (
+                                <BrevMottakere behandlingId={behandling.id} />
+                            ) : (
+                                <BaksBrevmottakerContainer behandlingId={behandling.id} />
+                            ))}
                         {behandlingErRedigerbar && brevRessurs.status === RessursStatus.SUKSESS && (
-                            <StyledKnapp
-                                variant="primary"
-                                size="medium"
-                                onClick={() => {
-                                    settVisModal(true);
-                                }}
+                            <Button
+                                variant={'primary'}
+                                size={'medium'}
+                                onClick={() => settVisModal(true)}
                             >
                                 Ferdigstill behandling og send brev
-                            </StyledKnapp>
+                            </Button>
                         )}
-                    </div>
+                    </VStack>
                     <PdfVisning pdfFilInnhold={brevRessurs} />
-                </BrevContainer>
+                </HGrid>
                 <ModalWrapper
                     tittel={'Bekreft utsending av brev'}
                     visModal={visModal}

--- a/src/frontend/Komponenter/Behandling/Brev/BrevFane.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevFane.tsx
@@ -12,5 +12,5 @@ export const BrevFane: React.FC<Props> = ({ behandling }) => {
         return <BrevFaneUtenBrev behandlingId={behandling.id} />;
     }
 
-    return <Brev behandlingId={behandling.id} />;
+    return <Brev behandling={behandling} />;
 };

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/BrevmottakerContainer.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/BrevmottakerContainer.tsx
@@ -75,7 +75,7 @@ export function BrevmottakerContainer({ behandlingId }: Props) {
 
     if (brevmottakere.status === RessursStatus.HENTER) {
         return (
-            <Box background={'surface-info-subtle'} width={'100%'} maxWidth={'1000px'}>
+            <Box background={'surface-info-subtle'} width={'100%'}>
                 <Skeleton
                     width={'100%'}
                     height={150}

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/panel/BrevmottakerPanel.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/panel/BrevmottakerPanel.tsx
@@ -16,7 +16,7 @@ export function BrevmottakerPanel({ brevmottakere }: Props) {
     const oppsumertBrevmottakere = utledOppsumertBrevmottakere(brevmottakere);
 
     return (
-        <Box background={'surface-info-subtle'} padding={'10'} width={'100%'} maxWidth={'1000px'}>
+        <Box background={'surface-info-subtle'} padding={'6'}>
             <HStack justify={'space-between'} align={'center'}>
                 <Label htmlFor={'brevmottakere_liste'}>Brevmottakere</Label>
                 {behandlingErRedigerbar && (


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23444

Kobler sammen koden for brevmottakere laget i en tidligere [PR](https://github.com/navikt/familie-klage-frontend/pull/867) sammen med den eksisterende koden.

Har kjørt løsningen lokalt og det ser ut til å fungere fint. 