### PR TITLE
Feature - deliger oppgave til saksbehandler som tar klagebehandling av vent

### DIFF
--- a/src/frontend/App/typer/toast.ts
+++ b/src/frontend/App/typer/toast.ts
@@ -8,11 +8,12 @@ export enum EToast {
 }
 
 export const toastTilTekst: Record<EToast, string> = {
-    VEDTAK_UNDERKJENT: 'Vedtak underkjent',
-    BEHANDLING_HENLAGT: 'Behandlingen er henlagt',
+    VEDTAK_UNDERKJENT: 'Vedtak underkjent.',
+    BEHANDLING_HENLAGT: 'Behandlingen er henlagt.',
     TILBAKEKREVING_OPPRETTET:
         'Tilbakekreving blir opprettet. NB! Det kan ta litt tid før du kan se den i behandlingsoversikten.',
-    BREVMOTTAKERE_SATT: 'Brevmottakere er satt',
-    BEHANDLING_SATT_PÅ_VENT: 'Oppgaven er oppdatert og behandlingen er satt på vent',
-    BEHANDLING_TATT_AV_VENT: 'Behandlingen er tatt av vent. Du er satt som ansvarlig saksbehandler',
+    BREVMOTTAKERE_SATT: 'Brevmottakere er satt.',
+    BEHANDLING_SATT_PÅ_VENT: 'Oppgaven er oppdatert og behandlingen er satt på vent.',
+    BEHANDLING_TATT_AV_VENT:
+        'Behandlingen er tatt av vent. Du er satt som ansvarlig saksbehandler.',
 };

--- a/src/frontend/App/typer/toast.ts
+++ b/src/frontend/App/typer/toast.ts
@@ -3,6 +3,8 @@ export enum EToast {
     BEHANDLING_HENLAGT = 'BEHANDLING_HENLAGT',
     TILBAKEKREVING_OPPRETTET = 'TILBAKEKREVING_OPPRETTET',
     BREVMOTTAKERE_SATT = 'BREVMOTTAKERE_SATT',
+    BEHANDLING_SATT_PÅ_VENT = 'BEHANDLING_SATT_PÅ_VENT',
+    BEHANDLING_TATT_AV_VENT = 'BEHANDLING_TATT_AV_VENT',
 }
 
 export const toastTilTekst: Record<EToast, string> = {
@@ -11,4 +13,6 @@ export const toastTilTekst: Record<EToast, string> = {
     TILBAKEKREVING_OPPRETTET:
         'Tilbakekreving blir opprettet. NB! Det kan ta litt tid før du kan se den i behandlingsoversikten.',
     BREVMOTTAKERE_SATT: 'Brevmottakere er satt',
+    BEHANDLING_SATT_PÅ_VENT: 'Oppgaven er oppdatert og behandlingen er satt på vent',
+    BEHANDLING_TATT_AV_VENT: 'Behandlingen er tatt av vent. Du er satt som ansvarlig saksbehandler',
 };

--- a/src/frontend/Felles/Toast/Toast.tsx
+++ b/src/frontend/Felles/Toast/Toast.tsx
@@ -3,8 +3,8 @@ import React, { useEffect } from 'react';
 import styled from 'styled-components';
 
 import { useApp } from '../../App/context/AppContext';
-import { toastTilTekst } from '../../App/typer/toast';
-import { Alert } from '@navikt/ds-react';
+import { EToast, toastTilTekst } from '../../App/typer/toast';
+import { AlertMedLukkeknapp } from '../Visningskomponenter/Alerts';
 
 const Container = styled.div`
     z-index: 9999;
@@ -12,6 +12,16 @@ const Container = styled.div`
     right: 2rem;
     top: 4rem;
 `;
+
+const ToastAlert: React.FC<{ toast: EToast }> = ({ toast }) => {
+    return (
+        <Container>
+            <AlertMedLukkeknapp variant={'success'} keyProp={toast}>
+                {toastTilTekst[toast]}
+            </AlertMedLukkeknapp>
+        </Container>
+    );
+};
 
 export const Toast: React.FC = () => {
     const { toast, settToast } = useApp();
@@ -23,9 +33,5 @@ export const Toast: React.FC = () => {
         return () => clearTimeout(timer);
     });
 
-    return toast ? (
-        <Container>
-            <Alert variant={'success'}>{toastTilTekst[toast]}</Alert>
-        </Container>
-    ) : null;
+    return toast ? <ToastAlert toast={toast} /> : null;
 };

--- a/src/frontend/Felles/Toast/Toast.tsx
+++ b/src/frontend/Felles/Toast/Toast.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import { useApp } from '../../App/context/AppContext';
 import { EToast, toastTilTekst } from '../../App/typer/toast';
-import { AlertMedLukkeknapp } from '../Visningskomponenter/Alerts';
+import { AlertMedLukkeKnapp } from '../Visningskomponenter/Alerts';
 
 const Container = styled.div`
     z-index: 9999;
@@ -16,9 +16,9 @@ const Container = styled.div`
 const ToastAlert: React.FC<{ toast: EToast }> = ({ toast }) => {
     return (
         <Container>
-            <AlertMedLukkeknapp variant={'success'} keyProp={toast}>
+            <AlertMedLukkeKnapp variant={'success'} keyProp={toast}>
                 {toastTilTekst[toast]}
-            </AlertMedLukkeknapp>
+            </AlertMedLukkeKnapp>
         </Container>
     );
 };

--- a/src/frontend/Felles/Visningskomponenter/Alerts.tsx
+++ b/src/frontend/Felles/Visningskomponenter/Alerts.tsx
@@ -1,0 +1,52 @@
+import React, { forwardRef, ReactNode, useEffect, useState } from 'react';
+import { Alert, AlertProps } from '@navikt/ds-react';
+
+export const AlertError = forwardRef<HTMLDivElement, Omit<AlertProps, 'variant'>>((props, ref) => {
+    return <Alert variant={'error'} {...props} ref={ref} />;
+});
+
+export const AlertSuccess = forwardRef<HTMLDivElement, Omit<AlertProps, 'variant'>>(
+    (props, ref) => {
+        return <Alert variant={'success'} {...props} ref={ref} />;
+    }
+);
+
+export const AlertInfo = forwardRef<HTMLDivElement, Omit<AlertProps, 'variant'>>((props, ref) => {
+    return <Alert variant={'info'} {...props} ref={ref} />;
+});
+
+export const AlertWarning = forwardRef<HTMLDivElement, Omit<AlertProps, 'variant'>>(
+    (props, ref) => {
+        return <Alert variant={'warning'} {...props} ref={ref} />;
+    }
+);
+
+export const AlertMedLukkeknapp = ({
+    variant,
+    children,
+    keyProp,
+}: {
+    variant: AlertProps['variant'];
+    children: ReactNode;
+    keyProp: string;
+}) => {
+    const [skalVise, settSkalVise] = useState(true);
+
+    useEffect(() => {
+        settSkalVise(true);
+    }, [keyProp]);
+
+    return (
+        skalVise && (
+            <Alert size="small" variant={variant} closeButton onClose={() => settSkalVise(false)}>
+                {children}
+            </Alert>
+        )
+    );
+};
+
+AlertError.displayName = 'AlertError';
+AlertSuccess.displayName = 'AlertSuccess';
+AlertInfo.displayName = 'AlertInfo';
+AlertWarning.displayName = 'AlertWarning';
+AlertMedLukkeknapp.displayName = 'AlertMedLukkeknapp';

--- a/src/frontend/Felles/Visningskomponenter/Alerts.tsx
+++ b/src/frontend/Felles/Visningskomponenter/Alerts.tsx
@@ -21,7 +21,7 @@ export const AlertWarning = forwardRef<HTMLDivElement, Omit<AlertProps, 'variant
     }
 );
 
-export const AlertMedLukkeknapp = ({
+export const AlertMedLukkeKnapp = ({
     variant,
     children,
     keyProp,
@@ -49,4 +49,4 @@ AlertError.displayName = 'AlertError';
 AlertSuccess.displayName = 'AlertSuccess';
 AlertInfo.displayName = 'AlertInfo';
 AlertWarning.displayName = 'AlertWarning';
-AlertMedLukkeknapp.displayName = 'AlertMedLukkeknapp';
+AlertMedLukkeKnapp.displayName = 'AlertMedLukkeknapp';

--- a/src/frontend/Komponenter/Behandling/SettPåVent/SettPåVent.tsx
+++ b/src/frontend/Komponenter/Behandling/SettPåVent/SettPåVent.tsx
@@ -20,6 +20,7 @@ import { FristVelger } from './FristVelger';
 import { EksisterendeBeskrivelse } from './EksisterendeBeskrivelse';
 import { SettPåVentKnappValg } from './SettPåVentKnappValg';
 import { MappeVelger } from './MappeVelger';
+import { EToast } from '../../../App/typer/toast';
 
 const StyledVStack = styled(VStack)`
     background-color: #e6f1f8;
@@ -58,7 +59,7 @@ export const SettPåVent: FC<{ behandling: Behandling }> = ({ behandling }) => {
     const { visSettPåVent, settVisSettPåVent, hentBehandling, hentAnsvarligSaksbehandler } =
         useBehandling();
 
-    const { axiosRequest } = useApp();
+    const { axiosRequest, settToast } = useApp();
 
     const hentOppgaveForBehandling = useCallback(() => {
         axiosRequest<IOppgave, null>({
@@ -115,6 +116,7 @@ export const SettPåVent: FC<{ behandling: Behandling }> = ({ behandling }) => {
                         nullstillOppgaveFelt();
                         settVisSettPåVent(false);
                         hentBehandlingshistorikk.rerun();
+                        settToast(EToast.BEHANDLING_SATT_PÅ_VENT);
                     } else {
                         settFeilmelding(respons.frontendFeilmelding);
                     }
@@ -138,6 +140,7 @@ export const SettPåVent: FC<{ behandling: Behandling }> = ({ behandling }) => {
                     hentBehandling.rerun();
                     hentBehandlingshistorikk.rerun();
                     hentAnsvarligSaksbehandler.rerun();
+                    settToast(EToast.BEHANDLING_TATT_AV_VENT);
                 } else {
                     settFeilmelding(respons.frontendFeilmelding);
                 }

--- a/src/frontend/Komponenter/Behandling/SettPåVent/SettPåVent.tsx
+++ b/src/frontend/Komponenter/Behandling/SettPåVent/SettPåVent.tsx
@@ -37,6 +37,7 @@ type SettPåVentRequest = {
     frist: string;
     mappe: number | undefined;
     beskrivelse: string;
+    oppgaveVersjon?: number;
 };
 
 export const SettPåVent: FC<{ behandling: Behandling }> = ({ behandling }) => {
@@ -104,6 +105,7 @@ export const SettPåVent: FC<{ behandling: Behandling }> = ({ behandling }) => {
                     frist: frist,
                     mappe: mappe,
                     beskrivelse: beskrivelse,
+                    oppgaveVersjon: oppgave.data.versjon,
                 },
             })
                 .then((respons: RessursFeilet | RessursSuksess<string>) => {

--- a/src/frontend/Komponenter/Behandling/SettPåVent/SettPåVent.tsx
+++ b/src/frontend/Komponenter/Behandling/SettPåVent/SettPåVent.tsx
@@ -55,7 +55,8 @@ export const SettPåVent: FC<{ behandling: Behandling }> = ({ behandling }) => {
 
     const erBehandlingPåVent = behandling.status === BehandlingStatus.SATT_PÅ_VENT;
 
-    const { visSettPåVent, settVisSettPåVent, hentBehandling } = useBehandling();
+    const { visSettPåVent, settVisSettPåVent, hentBehandling, hentAnsvarligSaksbehandler } =
+        useBehandling();
 
     const { axiosRequest } = useApp();
 
@@ -136,6 +137,7 @@ export const SettPåVent: FC<{ behandling: Behandling }> = ({ behandling }) => {
                 if (respons.status === RessursStatus.SUKSESS) {
                     hentBehandling.rerun();
                     hentBehandlingshistorikk.rerun();
+                    hentAnsvarligSaksbehandler.rerun();
                 } else {
                     settFeilmelding(respons.frontendFeilmelding);
                 }

--- a/src/frontend/Komponenter/Behandling/Typer/IOppgave.ts
+++ b/src/frontend/Komponenter/Behandling/Typer/IOppgave.ts
@@ -6,6 +6,7 @@ export interface IOppgave {
     fristFerdigstillelse?: string;
     prioritet?: Prioritet;
     beskrivelse: string;
+    versjon?: number;
 }
 
 export type Prioritet = 'HOY' | 'NORM' | 'LAV';


### PR DESCRIPTION
# Feature - deliger oppgave til saksbehandler som tar klagebehandling av vent

Denne PRen har som hensikt å addresse et funn fra testing, der den som tar behandlingen av vent blir deligert som ansvarlig saksbehandler. Vi sender også med oppgave versjon.

Det vises også nå en toast får når behandling er satt/tatt av vent. 

![image](https://github.com/user-attachments/assets/a1d44a6a-3c9b-4f36-82d9-ced3be079614)

Denne [PRen](https://github.com/navikt/familie-klage-frontend/compare/main...feature/vent-oppgave-versjon) depender på denne [PRen](https://github.com/navikt/familie-klage/pull/571) (back-end).

Funn fra test og oppgave kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-22627).