### PR TITLE
Bugfiks - visningsmodus er nå satt til visning etter man har lagret formkrav for "har ikke klaget på vedtak"

### DIFF
--- a/src/frontend/Komponenter/Behandling/Formkrav/validerFormkravUtils.ts
+++ b/src/frontend/Komponenter/Behandling/Formkrav/validerFormkravUtils.ts
@@ -76,9 +76,13 @@ export const utledRedigeringsmodus = (
     if (!behandlingErRedigerbar) {
         return Redigeringsmodus.VISNING;
     }
-    if (alleVurderingerErStatus(vurderinger, VilkårStatus.IKKE_SATT)) {
+
+    if (vurderinger.påklagetVedtak.påklagetVedtakstype === PåklagetVedtakstype.UTEN_VEDTAK) {
+        return Redigeringsmodus.VISNING;
+    } else if (alleVurderingerErStatus(vurderinger, VilkårStatus.IKKE_SATT)) {
         return Redigeringsmodus.IKKE_PÅSTARTET;
     }
+
     return Redigeringsmodus.VISNING;
 };
 


### PR DESCRIPTION
# Bugfiks - visningsmodus er nå satt til visning etter man har lagret formkrav for "har ikke klaget på vedtak"

### Hvorfor er denne endringen nødvendig? ✨ 

![Skjermbilde 2025-01-31 kl  12 30 26](https://github.com/user-attachments/assets/ecc00f41-a509-42e1-b438-d99497a17032)

En liten bug der feil visningsmodus blir satt når bruker trykker lagre på "ikke klaget på vedtak" formkravet. Selve lagringen skjer, men visningsmodus ble feil. Denne endringen fikser dette. 

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-24140).

### Verdt å nevne

Har testet ved å prøve de forskjellige valgene. Prøvd å ta for meg de forskjellige statene som kan påvirke dette, men virker som det ikke er noen tilfeller der dette blir feil. 