### PR TITLE
bugfix: skal kunne vise pdf i lesevisning

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/Brev.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Brev.tsx
@@ -126,10 +126,6 @@ export const Brev: React.FC<Props> = ({ behandling }: Props) => {
         settFeilmelding('');
     };
 
-    if (!behandlingErRedigerbar) {
-        return <></>;
-    }
-
     if (utfall === 'LAG_BREV') {
         return (
             <Brevside>


### PR DESCRIPTION
En kodesnutt som ble lagt til tidligere fjernet lesevisning av pdf ved opprettholdelse. Denne PRen fikser dette.