### PR TITLE
Går over til nytt endepunkt for brevmottakere for team EF

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brevmottakere/ef/BrevMottakere.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/ef/BrevMottakere.tsx
@@ -102,7 +102,7 @@ const BrevMottakere: React.FC<{ behandlingId: string }> = ({ behandlingId }) => 
     const hentBrevmottakere = useCallback(() => {
         const behandlingConfig: AxiosRequestConfig = {
             method: 'GET',
-            url: `/familie-klage/api/brev/${behandlingId}/mottakere`,
+            url: `/familie-klage/api/brevmottaker/${behandlingId}`,
         };
         axiosRequest<Brevmottakere, null>(behandlingConfig).then((res: Ressurs<Brevmottakere>) =>
             settMottakere(res)

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/ef/BrevmottakereModal.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/ef/BrevmottakereModal.tsx
@@ -63,11 +63,11 @@ export const BrevmottakereModal: FC<{
     const [innsendingSuksess, settInnsendingSukksess] = useState(false);
     const { settToast, axiosRequest } = useApp();
 
-    const kallSettBrevmottakere = useCallback(
+    const kallErstattBrevmottakere = useCallback(
         (brevmottakere: Brevmottakere) =>
             axiosRequest<Brevmottakere, Brevmottakere>({
-                url: `familie-klage/api/brev/${behandlingId}/mottakere`,
-                method: 'POST',
+                url: `familie-klage/api/brevmottaker/${behandlingId}`,
+                method: 'PUT',
                 data: brevmottakere,
             }),
         [axiosRequest, behandlingId]
@@ -81,7 +81,7 @@ export const BrevmottakereModal: FC<{
     const settBrevmottakere = () => {
         settFeilmelding('');
         settInnsendingSukksess(false);
-        kallSettBrevmottakere({
+        kallErstattBrevmottakere({
             personer: valgtePersonMottakere,
             organisasjoner: valgteOrganisasjonMottakere,
         }).then((response: RessursSuksess<Brevmottakere> | RessursFeilet) => {


### PR DESCRIPTION
Tar i bruk nytt endepunkt introdusert her: https://github.com/navikt/familie-klage/pull/580/files#diff-0605af2946628192a02eec366e875835c1e4979bdf3cb4a75b47ec67f867b74dR41-R51

Hvis man går over til den endepunktet kan man fjerne brevmottaker koden i PRen her: https://github.com/navikt/familie-klage/pull/585

Har kjørt og opp løsningen lokalt og ser ut til å fungere fint ut i fra det jeg ser. 