### PR TITLE
NAV-24253: Viser baks brevmottaker komponenter, bak en toggle

### DIFF
--- a/src/frontend/App/context/toggles.ts
+++ b/src/frontend/App/context/toggles.ts
@@ -7,4 +7,6 @@ export enum ToggleName {
 
     // Release-toggles
     visSettPåVent = 'familie.klage.sett-pa-vent',
+    visBrevmottakerBaks = 'familie-klage.vis-brevmottaker-baks',
+    leggTilBrevmottakerBaks = 'familie-klage.legg-til-brevmottaker-baks',
 }

--- a/src/frontend/Komponenter/Behandling/Brev/Brev.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Brev.tsx
@@ -18,7 +18,10 @@ import { ModalWrapper } from '../../../Felles/Modal/ModalWrapper';
 import SystemetLaster from '../../../Felles/SystemetLaster/SystemetLaster';
 import BrevMottakere from '../Brevmottakere/ef/BrevMottakere';
 import { OmgjørVedtak } from './OmgjørVedtak';
-import { Behandling } from '../../../App/typer/fagsak';
+import { Behandling, Fagsystem } from '../../../App/typer/fagsak';
+import { BrevmottakerContainer as BaksBrevmottakerContainer } from '../Brevmottakere/baks/BrevmottakerContainer';
+import { useToggles } from '../../../App/context/TogglesContext';
+import { ToggleName } from '../../../App/context/toggles';
 
 const Brevside = styled.div`
     background-color: var(--a-bg-subtle);
@@ -40,6 +43,7 @@ export const Brev: React.FC<Props> = ({ behandling }: Props) => {
 
     const { hentBehandling, hentBehandlingshistorikk, behandlingErRedigerbar } = useBehandling();
     const navigate = useNavigate();
+    const { toggles } = useToggles();
 
     const { axiosRequest } = useApp();
     const [senderInn, settSenderInn] = useState<boolean>(false);
@@ -126,14 +130,20 @@ export const Brev: React.FC<Props> = ({ behandling }: Props) => {
         settFeilmelding('');
     };
 
+    const erFagsystemBAKS =
+        behandling.fagsystem !== Fagsystem.EF && toggles[ToggleName.visBrevmottakerBaks];
+
     if (utfall === 'LAG_BREV') {
         return (
             <Brevside>
                 <HGrid gap={'6'} columns={{ xl: 1, '2xl': '1fr 1.2fr' }}>
                     <VStack gap={'6'}>
-                        {brevRessurs.status === RessursStatus.SUKSESS && (
-                            <BrevMottakere behandlingId={behandling.id} />
-                        )}
+                        {brevRessurs.status === RessursStatus.SUKSESS &&
+                            (erFagsystemBAKS ? (
+                                <BaksBrevmottakerContainer behandlingId={behandling.id} />
+                            ) : (
+                                <BrevMottakere behandlingId={behandling.id} />
+                            ))}
                         {behandlingErRedigerbar && brevRessurs.status === RessursStatus.SUKSESS && (
                             <Button
                                 variant={'primary'}

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/BrevmottakerContainer.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/BrevmottakerContainer.tsx
@@ -19,6 +19,8 @@ import { Brevmottakere } from '../brevmottakere';
 import { erBrevmottakerPersonUtenIdent } from '../brevmottaker';
 import { NyBrevmottaker } from '../nyBrevmottaker';
 import { SlettbarBrevmottaker } from '../slettbarBrevmottaker';
+import { useToggles } from '../../../../App/context/TogglesContext';
+import { ToggleName } from '../../../../App/context/toggles';
 
 const API_BASE_URL = `/familie-klage/api/brevmottaker`;
 
@@ -29,6 +31,8 @@ type Props = {
 export function BrevmottakerContainer({ behandlingId }: Props) {
     const { axiosRequest } = useApp();
     const { personopplysningerResponse: personopplysninger } = useBehandling();
+    const { toggles } = useToggles();
+
     const [brevmottakere, settBrevmottakere] = useState<Ressurs<Brevmottakere>>(byggTomRessurs());
 
     async function hentBrevmottakere(): Promise<boolean> {
@@ -98,14 +102,16 @@ export function BrevmottakerContainer({ behandlingId }: Props) {
                 return (
                     <>
                         <BrevmottakerPanel brevmottakere={brevmottakere} />
-                        <BrevmottakerModal
-                            behandlingId={behandlingId}
-                            personopplysninger={personopplysninger}
-                            brevmottakere={brevmottakerePersonUtenIdent}
-                            opprettBrevmottaker={opprettBrevmottaker}
-                            slettBrevmottaker={slettBrevmottaker}
-                            erLesevisning={false}
-                        />
+                        {toggles[ToggleName.leggTilBrevmottakerBaks] && (
+                            <BrevmottakerModal
+                                behandlingId={behandlingId}
+                                personopplysninger={personopplysninger}
+                                brevmottakere={brevmottakerePersonUtenIdent}
+                                opprettBrevmottaker={opprettBrevmottaker}
+                                slettBrevmottaker={slettBrevmottaker}
+                                erLesevisning={false}
+                            />
+                        )}
                     </>
                 );
             }}

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/panel/BrevmottakerPanel.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/panel/BrevmottakerPanel.tsx
@@ -4,6 +4,8 @@ import { useBehandling } from '../../../../../App/context/BehandlingContext';
 import { BodyShort, Box, Button, HStack, Label, Tooltip } from '@navikt/ds-react';
 import { utledOppsumertBrevmottakere } from '../oppsumertBrevmottaker';
 import { Brevmottakere } from '../../brevmottakere';
+import { useToggles } from '../../../../../App/context/TogglesContext';
+import { ToggleName } from '../../../../../App/context/toggles';
 
 type Props = {
     brevmottakere: Brevmottakere;
@@ -11,6 +13,7 @@ type Props = {
 
 export function BrevmottakerPanel({ brevmottakere }: Props) {
     const { settVisBrevmottakereModal } = useApp();
+    const { toggles } = useToggles();
     const { behandlingErRedigerbar } = useBehandling();
 
     const oppsumertBrevmottakere = utledOppsumertBrevmottakere(brevmottakere);
@@ -19,7 +22,7 @@ export function BrevmottakerPanel({ brevmottakere }: Props) {
         <Box background={'surface-info-subtle'} padding={'6'}>
             <HStack justify={'space-between'} align={'center'}>
                 <Label htmlFor={'brevmottakere_liste'}>Brevmottakere</Label>
-                {behandlingErRedigerbar && (
+                {behandlingErRedigerbar && toggles[ToggleName.leggTilBrevmottakerBaks] && (
                     <Tooltip content={'Legg til eller fjern brevmottakere'}>
                         <Button
                             variant={'tertiary'}


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24253

Viser brevmottaker komponenter for BAKS når fagsystemet er KS eller BA, og toggle(s) er skrudd på.

En toggle for å vise selve brevmottaker panelet til BAKS.
En annen toggle for å vise knappen for å vise modalen for å legge til manuelle brevmottakere. 

Har kjørt løsningen opp lokalt og det ser ut til å fungere fint. 