### PR TITLE
Utvider innstilling til Nav klageinstans med flere felter

### DIFF
--- a/src/frontend/Komponenter/Behandling/Vurdering/InnstillingTilNavKlageinstans/InnstillingTilNavKlageinstans.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/InnstillingTilNavKlageinstans/InnstillingTilNavKlageinstans.tsx
@@ -2,9 +2,8 @@ import { EnsligTextArea } from '../../../../Felles/Input/EnsligTextArea';
 import * as React from 'react';
 import { IVurdering } from '../vurderingValg';
 import { Behandling, Fagsystem } from '../../../../App/typer/fagsak';
-import styled from 'styled-components';
 import { LesMerOmInnstilling } from './LesMerOmInnstilling';
-import { Accordion, Heading } from '@navikt/ds-react';
+import { Accordion, Box, Heading } from '@navikt/ds-react';
 import { InnstillingTilNavKlageinstansAvsnitt } from './InnstillingTilNavKlageinstansAvsnitt';
 
 interface Props {
@@ -15,15 +14,6 @@ interface Props {
     settVurderingEndret: (endret: boolean) => void;
 }
 
-const FritekstFeltWrapper = styled.div`
-    margin: 2rem 4rem 2rem 4rem;
-`;
-
-const StyledAccordion = styled(Accordion)`
-    margin: 2rem 4rem 2rem 4rem;
-    max-width: 40rem;
-`;
-
 export const InnstillingTilNavKlageinstans = ({
     behandling,
     oppdatertVurdering,
@@ -32,7 +22,7 @@ export const InnstillingTilNavKlageinstans = ({
     settVurderingEndret,
 }: Props) => {
     return behandling.fagsystem === Fagsystem.EF ? (
-        <FritekstFeltWrapper>
+        <Box marginInline="16" marginBlock="8">
             <EnsligTextArea
                 label="Innstilling til Nav Klageinstans (kommer med i brev til bruker)"
                 value={oppdatertVurdering.innstillingKlageinstans}
@@ -48,52 +38,54 @@ export const InnstillingTilNavKlageinstans = ({
                 readOnly={false}
             />
             <LesMerOmInnstilling />
-        </FritekstFeltWrapper>
+        </Box>
     ) : (
-        <StyledAccordion size="small" headingSize="xsmall">
-            <Heading spacing size="medium" level="3">
-                Innstilling til Nav Klageinstans (kommer med i brev til bruker)
-            </Heading>
-            <InnstillingTilNavKlageinstansAvsnitt
-                tittel="Dokumentasjon og utredning"
-                verdi={oppdatertVurdering.dokumentasjonOgUtredning}
-                felt="dokumentasjonOgUtredning"
-                settIkkePersistertKomponent={settIkkePersistertKomponent}
-                settOppdatertVurdering={settOppdatertVurdering}
-                settVurderingEndret={settVurderingEndret}
-            />
-            <InnstillingTilNavKlageinstansAvsnitt
-                tittel="Spørsmålet i saken"
-                verdi={oppdatertVurdering.spørsmåletISaken}
-                felt="spørsmåletISaken"
-                settIkkePersistertKomponent={settIkkePersistertKomponent}
-                settOppdatertVurdering={settOppdatertVurdering}
-                settVurderingEndret={settVurderingEndret}
-            />
-            <InnstillingTilNavKlageinstansAvsnitt
-                tittel="Aktuelle rettskilder"
-                verdi={oppdatertVurdering.aktuelleRettskilder}
-                felt="aktuelleRettskilder"
-                settIkkePersistertKomponent={settIkkePersistertKomponent}
-                settOppdatertVurdering={settOppdatertVurdering}
-                settVurderingEndret={settVurderingEndret}
-            />
-            <InnstillingTilNavKlageinstansAvsnitt
-                tittel="Klagers anførsler"
-                verdi={oppdatertVurdering.klagersAnførsler}
-                felt="klagersAnførsler"
-                settIkkePersistertKomponent={settIkkePersistertKomponent}
-                settOppdatertVurdering={settOppdatertVurdering}
-                settVurderingEndret={settVurderingEndret}
-            />
-            <InnstillingTilNavKlageinstansAvsnitt
-                tittel="Vurdering av klagen"
-                verdi={oppdatertVurdering.vurderingAvKlagen}
-                felt="vurderingAvKlagen"
-                settIkkePersistertKomponent={settIkkePersistertKomponent}
-                settOppdatertVurdering={settOppdatertVurdering}
-                settVurderingEndret={settVurderingEndret}
-            />
-        </StyledAccordion>
+        <Box maxWidth="40rem" marginInline="16" marginBlock="8">
+            <Accordion size="small" headingSize="xsmall">
+                <Heading spacing size="medium" level="3">
+                    Innstilling til Nav Klageinstans (kommer med i brev til bruker)
+                </Heading>
+                <InnstillingTilNavKlageinstansAvsnitt
+                    tittel="Dokumentasjon og utredning"
+                    verdi={oppdatertVurdering.dokumentasjonOgUtredning}
+                    felt="dokumentasjonOgUtredning"
+                    settIkkePersistertKomponent={settIkkePersistertKomponent}
+                    settOppdatertVurdering={settOppdatertVurdering}
+                    settVurderingEndret={settVurderingEndret}
+                />
+                <InnstillingTilNavKlageinstansAvsnitt
+                    tittel="Spørsmålet i saken"
+                    verdi={oppdatertVurdering.spørsmåletISaken}
+                    felt="spørsmåletISaken"
+                    settIkkePersistertKomponent={settIkkePersistertKomponent}
+                    settOppdatertVurdering={settOppdatertVurdering}
+                    settVurderingEndret={settVurderingEndret}
+                />
+                <InnstillingTilNavKlageinstansAvsnitt
+                    tittel="Aktuelle rettskilder"
+                    verdi={oppdatertVurdering.aktuelleRettskilder}
+                    felt="aktuelleRettskilder"
+                    settIkkePersistertKomponent={settIkkePersistertKomponent}
+                    settOppdatertVurdering={settOppdatertVurdering}
+                    settVurderingEndret={settVurderingEndret}
+                />
+                <InnstillingTilNavKlageinstansAvsnitt
+                    tittel="Klagers anførsler"
+                    verdi={oppdatertVurdering.klagersAnførsler}
+                    felt="klagersAnførsler"
+                    settIkkePersistertKomponent={settIkkePersistertKomponent}
+                    settOppdatertVurdering={settOppdatertVurdering}
+                    settVurderingEndret={settVurderingEndret}
+                />
+                <InnstillingTilNavKlageinstansAvsnitt
+                    tittel="Vurdering av klagen"
+                    verdi={oppdatertVurdering.vurderingAvKlagen}
+                    felt="vurderingAvKlagen"
+                    settIkkePersistertKomponent={settIkkePersistertKomponent}
+                    settOppdatertVurdering={settOppdatertVurdering}
+                    settVurderingEndret={settVurderingEndret}
+                />
+            </Accordion>
+        </Box>
     );
 };

--- a/src/frontend/Komponenter/Behandling/Vurdering/InnstillingTilNavKlageinstans/InnstillingTilNavKlageinstans.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/InnstillingTilNavKlageinstans/InnstillingTilNavKlageinstans.tsx
@@ -7,7 +7,7 @@ import { LesMerOmInnstilling } from './LesMerOmInnstilling';
 import { Accordion, Heading } from '@navikt/ds-react';
 import { InnstillingTilNavKlageinstansAvsnitt } from './InnstillingTilNavKlageinstansAvsnitt';
 
-interface IProps {
+interface Props {
     behandling: Behandling;
     oppdatertVurdering: IVurdering;
     settIkkePersistertKomponent: (verdi: string) => void;
@@ -30,7 +30,7 @@ export const InnstillingTilNavKlageinstans = ({
     settIkkePersistertKomponent,
     settOppdatertVurdering,
     settVurderingEndret,
-}: IProps) => {
+}: Props) => {
     return behandling.fagsystem === Fagsystem.EF ? (
         <FritekstFeltWrapper>
             <EnsligTextArea

--- a/src/frontend/Komponenter/Behandling/Vurdering/InnstillingTilNavKlageinstans/InnstillingTilNavKlageinstans.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/InnstillingTilNavKlageinstans/InnstillingTilNavKlageinstans.tsx
@@ -1,0 +1,99 @@
+import { EnsligTextArea } from '../../../../Felles/Input/EnsligTextArea';
+import * as React from 'react';
+import { IVurdering } from '../vurderingValg';
+import { Behandling, Fagsystem } from '../../../../App/typer/fagsak';
+import styled from 'styled-components';
+import { LesMerOmInnstilling } from './LesMerOmInnstilling';
+import { Accordion, Heading } from '@navikt/ds-react';
+import { InnstillingTilNavKlageinstansAvsnitt } from './InnstillingTilNavKlageinstansAvsnitt';
+
+interface IProps {
+    behandling: Behandling;
+    oppdatertVurdering: IVurdering;
+    settIkkePersistertKomponent: (verdi: string) => void;
+    settOppdatertVurdering: (vurdering: React.SetStateAction<IVurdering>) => void;
+    settVurderingEndret: (endret: boolean) => void;
+}
+
+const FritekstFeltWrapper = styled.div`
+    margin: 2rem 4rem 2rem 4rem;
+`;
+
+const StyledAccordion = styled(Accordion)`
+    margin: 2rem 4rem 2rem 4rem;
+    max-width: 40rem;
+`;
+
+export const InnstillingTilNavKlageinstans = ({
+    behandling,
+    oppdatertVurdering,
+    settIkkePersistertKomponent,
+    settOppdatertVurdering,
+    settVurderingEndret,
+}: IProps) => {
+    return behandling.fagsystem === Fagsystem.EF ? (
+        <FritekstFeltWrapper>
+            <EnsligTextArea
+                label="Innstilling til Nav Klageinstans (kommer med i brev til bruker)"
+                value={oppdatertVurdering.innstillingKlageinstans}
+                onChange={(e) => {
+                    settIkkePersistertKomponent(e.target.value);
+                    settOppdatertVurdering((tidligereTilstand) => ({
+                        ...tidligereTilstand,
+                        innstillingKlageinstans: e.target.value,
+                    }));
+                    settVurderingEndret(true);
+                }}
+                size="medium"
+                readOnly={false}
+            />
+            <LesMerOmInnstilling />
+        </FritekstFeltWrapper>
+    ) : (
+        <StyledAccordion size="small" headingSize="xsmall">
+            <Heading spacing size="medium" level="3">
+                Innstilling til Nav Klageinstans (kommer med i brev til bruker)
+            </Heading>
+            <InnstillingTilNavKlageinstansAvsnitt
+                tittel="Dokumentasjon og utredning"
+                verdi={oppdatertVurdering.dokumentasjonOgUtredning}
+                felt="dokumentasjonOgUtredning"
+                settIkkePersistertKomponent={settIkkePersistertKomponent}
+                settOppdatertVurdering={settOppdatertVurdering}
+                settVurderingEndret={settVurderingEndret}
+            />
+            <InnstillingTilNavKlageinstansAvsnitt
+                tittel="Spørsmålet i saken"
+                verdi={oppdatertVurdering.spørsmåletISaken}
+                felt="spørsmåletISaken"
+                settIkkePersistertKomponent={settIkkePersistertKomponent}
+                settOppdatertVurdering={settOppdatertVurdering}
+                settVurderingEndret={settVurderingEndret}
+            />
+            <InnstillingTilNavKlageinstansAvsnitt
+                tittel="Aktuelle rettskilder"
+                verdi={oppdatertVurdering.aktuelleRettskilder}
+                felt="aktuelleRettskilder"
+                settIkkePersistertKomponent={settIkkePersistertKomponent}
+                settOppdatertVurdering={settOppdatertVurdering}
+                settVurderingEndret={settVurderingEndret}
+            />
+            <InnstillingTilNavKlageinstansAvsnitt
+                tittel="Klagers anførsler"
+                verdi={oppdatertVurdering.klagersAnførsler}
+                felt="klagersAnførsler"
+                settIkkePersistertKomponent={settIkkePersistertKomponent}
+                settOppdatertVurdering={settOppdatertVurdering}
+                settVurderingEndret={settVurderingEndret}
+            />
+            <InnstillingTilNavKlageinstansAvsnitt
+                tittel="Vurdering av klagen"
+                verdi={oppdatertVurdering.vurderingAvKlagen}
+                felt="vurderingAvKlagen"
+                settIkkePersistertKomponent={settIkkePersistertKomponent}
+                settOppdatertVurdering={settOppdatertVurdering}
+                settVurderingEndret={settVurderingEndret}
+            />
+        </StyledAccordion>
+    );
+};

--- a/src/frontend/Komponenter/Behandling/Vurdering/InnstillingTilNavKlageinstans/InnstillingTilNavKlageinstansAvsnitt.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/InnstillingTilNavKlageinstans/InnstillingTilNavKlageinstansAvsnitt.tsx
@@ -3,7 +3,7 @@ import { Accordion } from '@navikt/ds-react';
 import { EnsligTextArea } from '../../../../Felles/Input/EnsligTextArea';
 import { IVurdering } from '../vurderingValg';
 
-interface IProps {
+interface Props {
     tittel: string;
     verdi: string | undefined;
     felt: keyof IVurdering;
@@ -19,7 +19,7 @@ export const InnstillingTilNavKlageinstansAvsnitt = ({
     settIkkePersistertKomponent,
     settOppdatertVurdering,
     settVurderingEndret,
-}: IProps) => {
+}: Props) => {
     return (
         <Accordion.Item>
             <Accordion.Header>{tittel}</Accordion.Header>

--- a/src/frontend/Komponenter/Behandling/Vurdering/InnstillingTilNavKlageinstans/InnstillingTilNavKlageinstansAvsnitt.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/InnstillingTilNavKlageinstans/InnstillingTilNavKlageinstansAvsnitt.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Accordion } from '@navikt/ds-react';
+import { EnsligTextArea } from '../../../../Felles/Input/EnsligTextArea';
+import { IVurdering } from '../vurderingValg';
+
+interface IProps {
+    tittel: string;
+    verdi: string | undefined;
+    felt: keyof IVurdering;
+    settIkkePersistertKomponent: (verdi: string) => void;
+    settOppdatertVurdering: (vurdering: React.SetStateAction<IVurdering>) => void;
+    settVurderingEndret: (endret: boolean) => void;
+}
+
+export const InnstillingTilNavKlageinstansAvsnitt = ({
+    tittel,
+    verdi,
+    felt,
+    settIkkePersistertKomponent,
+    settOppdatertVurdering,
+    settVurderingEndret,
+}: IProps) => {
+    return (
+        <Accordion.Item>
+            <Accordion.Header>{tittel}</Accordion.Header>
+            <Accordion.Content>
+                <EnsligTextArea
+                    label="Skriv tekst"
+                    value={verdi}
+                    onChange={(e) => {
+                        settIkkePersistertKomponent(e.target.value);
+                        settOppdatertVurdering((tidligereTilstand) => ({
+                            ...tidligereTilstand,
+                            [felt]: e.target.value,
+                        }));
+                        settVurderingEndret(true);
+                    }}
+                    size="medium"
+                    readOnly={false}
+                />
+            </Accordion.Content>
+        </Accordion.Item>
+    );
+};

--- a/src/frontend/Komponenter/Behandling/Vurdering/InnstillingTilNavKlageinstans/LesMerOmInnstilling.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/InnstillingTilNavKlageinstans/LesMerOmInnstilling.tsx
@@ -1,35 +1,31 @@
 import * as React from 'react';
-import styled from 'styled-components';
-import { ReadMore } from '@navikt/ds-react';
-
-const LesMerTekst = styled(ReadMore)`
-    margin-top: 0.25rem;
-    max-width: 40rem;
-`;
+import { Box, ReadMore } from '@navikt/ds-react';
 
 export const LesMerOmInnstilling = () => {
     return (
-        <LesMerTekst size="small" header="Dette skal innstillingen inneholde">
-            <ol>
-                <li>
-                    Hva klagesaken gjelder
-                    <ol type="a">
-                        <li>
-                            Skriv kort om resultatet i vedtaket. Eksempel: Klagers søknad om
-                            overgangsstønad ble avslått fordi hun har fått nytt barn med samme
-                            partner.
-                        </li>
-                    </ol>
-                </li>
-                <li>
-                    Vurdering av klagen
-                    <ol type="a">
-                        <li>Begrunn hvorfor vi opprettholder vedtaket</li>
-                        <li>Klagers argumenter skal vurderes/kommenteres</li>
-                        <li>Avslutt med konklusjon og vis til hjemmel</li>
-                    </ol>
-                </li>
-            </ol>
-        </LesMerTekst>
+        <Box maxWidth="40rem" marginBlock="2 0">
+            <ReadMore size="small" header="Dette skal innstillingen inneholde">
+                <ol>
+                    <li>
+                        Hva klagesaken gjelder
+                        <ol type="a">
+                            <li>
+                                Skriv kort om resultatet i vedtaket. Eksempel: Klagers søknad om
+                                overgangsstønad ble avslått fordi hun har fått nytt barn med samme
+                                partner.
+                            </li>
+                        </ol>
+                    </li>
+                    <li>
+                        Vurdering av klagen
+                        <ol type="a">
+                            <li>Begrunn hvorfor vi opprettholder vedtaket</li>
+                            <li>Klagers argumenter skal vurderes/kommenteres</li>
+                            <li>Avslutt med konklusjon og vis til hjemmel</li>
+                        </ol>
+                    </li>
+                </ol>
+            </ReadMore>
+        </Box>
     );
 };

--- a/src/frontend/Komponenter/Behandling/Vurdering/InnstillingTilNavKlageinstans/LesMerOmInnstilling.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/InnstillingTilNavKlageinstans/LesMerOmInnstilling.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import styled from 'styled-components';
+import { ReadMore } from '@navikt/ds-react';
+
+const LesMerTekst = styled(ReadMore)`
+    margin-top: 0.25rem;
+    max-width: 40rem;
+`;
+
+export const LesMerOmInnstilling = () => {
+    return (
+        <LesMerTekst size="small" header="Dette skal innstillingen inneholde">
+            <ol>
+                <li>
+                    Hva klagesaken gjelder
+                    <ol type="a">
+                        <li>
+                            Skriv kort om resultatet i vedtaket. Eksempel: Klagers søknad om
+                            overgangsstønad ble avslått fordi hun har fått nytt barn med samme
+                            partner.
+                        </li>
+                    </ol>
+                </li>
+                <li>
+                    Vurdering av klagen
+                    <ol type="a">
+                        <li>Begrunn hvorfor vi opprettholder vedtaket</li>
+                        <li>Klagers argumenter skal vurderes/kommenteres</li>
+                        <li>Avslutt med konklusjon og vis til hjemmel</li>
+                    </ol>
+                </li>
+            </ol>
+        </LesMerTekst>
+    );
+};

--- a/src/frontend/Komponenter/Behandling/Vurdering/vurderingValg.ts
+++ b/src/frontend/Komponenter/Behandling/Vurdering/vurderingValg.ts
@@ -7,6 +7,11 @@ export interface IVurdering {
     begrunnelseOmgjøring?: string;
     hjemmel?: Hjemmel;
     innstillingKlageinstans?: string;
+    dokumentasjonOgUtredning?: string;
+    spørsmåletISaken?: string;
+    aktuelleRettskilder?: string;
+    klagersAnførsler?: string;
+    vurderingAvKlagen?: string;
     interntNotat?: string;
 }
 


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24683)

I klager for barnetrygd og kontantstøtte må saksbehandlerne kunne fylle ut fem felter i innstilling til Nav Klageinstans, i stedet for ett.

- Legger til de nye feltene som optional i `IVurdering`
- Viser fem `Accordion` for de nye feltene dersom fagsystem er BA eller KS
- Tilpasser valideringen til fagsystem

![dd6f991be48613812248cce780ffd634](https://github.com/user-attachments/assets/89501d0c-dbbd-4aad-9288-6f0e9d5ad957)
![37d86b4151bc375b3fd92611847e2d4e](https://github.com/user-attachments/assets/1df5a540-5f46-496d-b9a1-0f5502a210f5)
![4df3b12024929e82dde780c3f59224e2](https://github.com/user-attachments/assets/3c60181a-9d10-4b7b-94c3-2ed46cccaae5)
