### PR TITLE
Sett første accordion i Innstilling til Nav Klageinstans som default åpen

### DIFF
--- a/src/frontend/Komponenter/Behandling/Vurdering/InnstillingTilNavKlageinstans/InnstillingTilNavKlageinstans.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/InnstillingTilNavKlageinstans/InnstillingTilNavKlageinstans.tsx
@@ -52,6 +52,7 @@ export const InnstillingTilNavKlageinstans = ({
                     settIkkePersistertKomponent={settIkkePersistertKomponent}
                     settOppdatertVurdering={settOppdatertVurdering}
                     settVurderingEndret={settVurderingEndret}
+                    defaultOpen
                 />
                 <InnstillingTilNavKlageinstansAvsnitt
                     tittel="Spørsmålet i saken"

--- a/src/frontend/Komponenter/Behandling/Vurdering/InnstillingTilNavKlageinstans/InnstillingTilNavKlageinstansAvsnitt.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/InnstillingTilNavKlageinstans/InnstillingTilNavKlageinstansAvsnitt.tsx
@@ -10,6 +10,7 @@ interface Props {
     settIkkePersistertKomponent: (verdi: string) => void;
     settOppdatertVurdering: (vurdering: React.SetStateAction<IVurdering>) => void;
     settVurderingEndret: (endret: boolean) => void;
+    defaultOpen?: boolean;
 }
 
 export const InnstillingTilNavKlageinstansAvsnitt = ({
@@ -19,9 +20,10 @@ export const InnstillingTilNavKlageinstansAvsnitt = ({
     settIkkePersistertKomponent,
     settOppdatertVurdering,
     settVurderingEndret,
+    defaultOpen,
 }: Props) => {
     return (
-        <Accordion.Item>
+        <Accordion.Item defaultOpen={defaultOpen}>
             <Accordion.Header>{tittel}</Accordion.Header>
             <Accordion.Content>
                 <EnsligTextArea


### PR DESCRIPTION
Vi ønsker at første accordion i Innstilling til Nav Klageinstans for behandlinger for BA og KS skal være default åpen

![5f5ad1b55fc2fd1b3871b6ca741033f7](https://github.com/user-attachments/assets/74497b33-76ef-423a-bdfe-5ef61d9a3c19)
