### PR TITLE
NAV-24774: Intern begrunnelse og fritekstfelt dersom unntak om klagefrist er oppfylt

### DIFF
--- a/src/frontend/Komponenter/Behandling/Formkrav/VisFormkravVurderinger.tsx
+++ b/src/frontend/Komponenter/Behandling/Formkrav/VisFormkravVurderinger.tsx
@@ -28,6 +28,7 @@ import {
     alleVilkårOppfylt,
     begrunnelseUtfylt,
     brevtekstUtfylt,
+    klagefristUnntakErValgtOgOppfylt,
     klagefristUnntakTattStillingTil,
     påKlagetVedtakValgt,
     utledIkkeUtfylteVilkår,
@@ -156,12 +157,18 @@ export const VisFormkravVurderinger: React.FC<IProps> = ({
 
     const radioKnapper = utledRadioKnapper(vurderinger);
     const alleVilkårErOppfylt = alleVilkårOppfylt(vurderinger);
+    const klagefristVilkårOppfylt = klagefristUnntakErValgtOgOppfylt(
+        vurderinger.klagefristOverholdtUnntak
+    );
     const påKlagetVedtakErValgt = påKlagetVedtakValgt(vurderinger);
     const harBegrunnelse = begrunnelseUtfylt(vurderinger);
     const harBrevtekst = brevtekstUtfylt(vurderinger);
     const manglerFritekster = !harBrevtekst || !harBegrunnelse;
     const ikkeUtfylteVilkår = utledIkkeUtfylteVilkår(vurderinger);
     const unntakFormalkravTattStillingTil = klagefristUnntakTattStillingTil(vurderinger);
+    const klagefristUnntakOppfylt = klagefristUnntakErValgtOgOppfylt(
+        vurderinger.klagefristOverholdtUnntak
+    );
     const ikkePåklagetVedtak =
         vurderinger.påklagetVedtak.påklagetVedtakstype === PåklagetVedtakstype.UTEN_VEDTAK;
 
@@ -173,7 +180,8 @@ export const VisFormkravVurderinger: React.FC<IProps> = ({
             ikkeUtfylteVilkår.length > 0 ||
             !unntakFormalkravTattStillingTil ||
             !påKlagetVedtakErValgt ||
-            (!alleVilkårErOppfylt && manglerFritekster)
+            ((!alleVilkårErOppfylt || (alleVilkårErOppfylt && klagefristUnntakOppfylt)) &&
+                manglerFritekster)
         );
     };
 
@@ -196,7 +204,8 @@ export const VisFormkravVurderinger: React.FC<IProps> = ({
 
     const urlSuffiks = utledUrlSuffiks();
 
-    const skalViseBegrunnelseOgBrevtekst = !alleVilkårErOppfylt || ikkePåklagetVedtak;
+    const skalViseBegrunnelseOgBrevtekst =
+        !alleVilkårErOppfylt || ikkePåklagetVedtak || klagefristVilkårOppfylt;
 
     return (
         <VisFormkravContainer>

--- a/src/frontend/Komponenter/Behandling/Formkrav/utils.ts
+++ b/src/frontend/Komponenter/Behandling/Formkrav/utils.ts
@@ -11,7 +11,7 @@ import { PåklagetVedtakstype } from '../../../App/typer/fagsak';
 import { compareDesc } from 'date-fns';
 import { formaterIsoDato, formaterIsoDatoTid } from '../../../App/utils/formatter';
 import { FagsystemVedtak } from '../../../App/typer/fagsystemVedtak';
-import { alleVilkårOppfylt } from './validerFormkravUtils';
+import { alleVilkårOppfylt, klagefristUnntakErValgtOgOppfylt } from './validerFormkravUtils';
 
 export const utledRadioKnapper = (vurderinger: IFormkravVilkår): IFormalkrav[] => {
     const { klagePart, klageKonkret, klagefristOverholdt, klageSignert } = vurderinger;
@@ -111,10 +111,14 @@ export const evaluerOmFelterSkalTilbakestilles = (vurderinger: IFormkravVilkår)
             : vurderinger;
 
     const alleVilkårErOppfylt = alleVilkårOppfylt(tilbakestillFormkrav);
+    const klagefristUnntakOppfylt = klagefristUnntakErValgtOgOppfylt(
+        vurderinger.klagefristOverholdtUnntak
+    );
 
-    const tilbakestillFritekstfelter = alleVilkårErOppfylt
-        ? { ...tilbakestillFormkrav, saksbehandlerBegrunnelse: '', brevtekst: undefined }
-        : tilbakestillFormkrav;
+    const tilbakestillFritekstfelter =
+        alleVilkårErOppfylt && !klagefristUnntakOppfylt
+            ? { ...tilbakestillFormkrav, saksbehandlerBegrunnelse: '', brevtekst: undefined }
+            : tilbakestillFormkrav;
 
     const tilbakestillUnntak =
         vurderinger.klagefristOverholdt === VilkårStatus.OPPFYLT


### PR DESCRIPTION
Favro: [NAV-24774](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24774)

Viser felt for intern begrunnelse samt fritekstfelt for begrunnelse til brev dersom alle formkrav er oppfylt med unntak av klagefrist-formkravet og et av unntakene til formkravet er oppfylt. I dette tilfellet vises også en annen hjelpetekst tilknyttet fritekstfeltet.

Justerer også validering av fritekst-feltene.

[Tilknyttet backend PR](https://github.com/navikt/familie-klage/pull/627).

Screenshots:
![image](https://github.com/user-attachments/assets/396cbfe1-4037-4321-bd6c-09ce8ef937e1)
