### PR TITLE
Vis nye felter i vurdering i lesemodus

### DIFF
--- a/src/frontend/Komponenter/Behandling/Vurdering/VurderingLesemodus.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/VurderingLesemodus.tsx
@@ -106,7 +106,7 @@ const OpprettholdVedtak: React.FC<{ vurdering: IVurdering }> = ({ vurdering }) =
                 vurderingAvKlagen) && (
                 <Avsnitt>
                     <Heading level="1" size="medium">
-                        Innstilling til NAV Klageinstans
+                        Innstilling til Nav Klageinstans
                     </Heading>
                 </Avsnitt>
             )}


### PR DESCRIPTION
De nye feltene som er lagt til i vurdering for behandlinger fra BA og KS må vises i lesemodus på vurderingsteget

![5a15f75f316b125018330002c39ece59](https://github.com/user-attachments/assets/816b9888-b20e-4730-9d1d-f82215adb9c1)

![68ff42f57eb3264989cd5ebcf0009067](https://github.com/user-attachments/assets/9f92b2eb-6def-4ecd-9622-fa4ca495827b)
