### PR TITLE
NAV-24862: Fjerne toggle for å vise brevmottaker BAKS variant

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/Brev.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Brev.tsx
@@ -19,8 +19,6 @@ import BrevMottakere from '../Brevmottakere/ef/BrevMottakere';
 import { OmgjørVedtak } from './OmgjørVedtak';
 import { Behandling, Fagsystem } from '../../../App/typer/fagsak';
 import { BrevmottakerContainer as BaksBrevmottakerContainer } from '../Brevmottakere/baks/BrevmottakerContainer';
-import { useToggles } from '../../../App/context/TogglesContext';
-import { ToggleName } from '../../../App/context/toggles';
 import { useFerdigstillBehandling } from './useFerdigstillBehandling';
 
 const Brevside = styled.div`
@@ -44,7 +42,6 @@ export const Brev: React.FC<Props> = ({ behandling }: Props) => {
     const [brevRessurs, settBrevRessurs] = useState<Ressurs<string>>(byggTomRessurs());
 
     const { behandlingErRedigerbar } = useBehandling();
-    const { toggles } = useToggles();
 
     const { axiosRequest } = useApp();
     const { ferdigstill, senderInn } = useFerdigstillBehandling(
@@ -112,20 +109,17 @@ export const Brev: React.FC<Props> = ({ behandling }: Props) => {
         settFeilmelding('');
     };
 
-    const erFagsystemBAKS =
-        behandling.fagsystem !== Fagsystem.EF && toggles[ToggleName.visBrevmottakerBaks];
-
     if (utfall === 'LAG_BREV') {
         return (
             <Brevside>
                 <HGrid gap={'6'} columns={{ xl: 1, '2xl': '1fr 1.2fr' }}>
                     <VStack gap={'6'}>
                         {brevRessurs.status === RessursStatus.SUKSESS &&
-                            (erFagsystemBAKS ? (
-                                <BaksBrevmottakerContainer behandlingId={behandling.id} />
-                            ) : (
-                                <BrevMottakere behandlingId={behandling.id} />
-                            ))}
+                        behandling.fagsystem !== Fagsystem.EF ? (
+                            <BaksBrevmottakerContainer behandlingId={behandling.id} />
+                        ) : (
+                            <BrevMottakere behandlingId={behandling.id} />
+                        )}
                         {behandlingErRedigerbar && brevRessurs.status === RessursStatus.SUKSESS && (
                             <Button
                                 variant={'primary'}


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24862

Toggle er skrudd på i prod og trengs ikke lengre. 

Relatert backend PR: https://github.com/navikt/familie-klage/pull/628