### PR TITLE
NAV-24779: Justere kode relatert til ferdigstilling av behandling

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/OmgjørVedtak.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/OmgjørVedtak.tsx
@@ -11,6 +11,7 @@ import { byggTomRessurs, Ressurs } from '../../../App/typer/ressurs';
 import DataViewer from '../../../Felles/DataViewer/DataViewer';
 import { ModalWrapper } from '../../../Felles/Modal/ModalWrapper';
 import styled from 'styled-components';
+import { useFerdigstillBehandling } from './useFerdigstillBehandling';
 
 const AlertContainer = styled.div`
     padding: 2rem;
@@ -56,19 +57,22 @@ const KanOppretteRevurderingTekst: React.FC<{ kanOppretteRevurdering: KanOpprett
 
 export const OmgjørVedtak: React.FC<{
     behandlingId: string;
-    ferdigstill: () => void;
-    senderInn: boolean;
-}> = ({ behandlingId, ferdigstill, senderInn }) => {
+}> = ({ behandlingId }) => {
     const { axiosRequest } = useApp();
     const { behandlingErRedigerbar } = useBehandling();
     const [visModal, settVisModal] = useState<boolean>(false);
     const [feilmelding, settFeilmelding] = useState('');
     const [kanOppretteRevurdering, settKanOppretteRevurdering] =
         useState<Ressurs<KanOppretteRevurdering>>(byggTomRessurs());
+    const { ferdigstill, senderInn } = useFerdigstillBehandling(
+        behandlingId,
+        () => lukkModal(),
+        (feilmelding) => settFeilmelding(feilmelding)
+    );
 
     const lukkModal = () => {
-        settVisModal(false);
         settFeilmelding('');
+        settVisModal(false);
     };
 
     useEffect(() => {

--- a/src/frontend/Komponenter/Behandling/Brev/useFerdigstillBehandling.ts
+++ b/src/frontend/Komponenter/Behandling/Brev/useFerdigstillBehandling.ts
@@ -1,0 +1,43 @@
+import { RessursFeilet, RessursStatus, RessursSuksess } from '../../../App/typer/ressurs';
+import { useState } from 'react';
+import { useBehandling } from '../../../App/context/BehandlingContext';
+import { useNavigate } from 'react-router-dom';
+import { useApp } from '../../../App/context/AppContext';
+
+export const useFerdigstillBehandling = (
+    behandlingId: string,
+    onSuccess: () => void,
+    onFailure: (feilmelding: string) => void
+) => {
+    const { hentBehandling, hentBehandlingshistorikk } = useBehandling();
+
+    const [senderInn, settSenderInn] = useState(false);
+    const navigate = useNavigate();
+    const { axiosRequest } = useApp();
+
+    const ferdigstill = () => {
+        if (senderInn) {
+            return;
+        }
+        settSenderInn(true);
+        axiosRequest<null, null>({
+            method: 'POST',
+            url: `/familie-klage/api/behandling/${behandlingId}/ferdigstill`,
+        }).then((res: RessursSuksess<null> | RessursFeilet) => {
+            settSenderInn(false);
+            if (res.status === RessursStatus.SUKSESS) {
+                onSuccess();
+                hentBehandling.rerun();
+                hentBehandlingshistorikk.rerun();
+                navigate(`/behandling/${behandlingId}/resultat`);
+            } else {
+                onFailure(res.frontendFeilmelding);
+            }
+        });
+    };
+
+    return {
+        ferdigstill,
+        senderInn,
+    };
+};


### PR DESCRIPTION
Favro: [NAV-24779](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24779)

Flytter duplisert "ferdigstillings"-kode inn i eget `hook` og tar i bruk `hooket` i henholdsvis `Brev`, `BrevFaneUtenBrev` og `OmgjørVedtak`.

[Tilhørende backend PR.](https://github.com/navikt/familie-klage/pull/629)