### PR TITLE
Bugfix: Markerer internId med en prefix for å skille på om det er en intern klagebehandling eller ekstern behandling

### DIFF
--- a/src/frontend/Komponenter/Behandling/Formkrav/VedtakSelect.tsx
+++ b/src/frontend/Komponenter/Behandling/Formkrav/VedtakSelect.tsx
@@ -45,13 +45,13 @@ export const VedtakSelect: React.FC<IProps> = ({
 }) => {
     const handleChange = (valgtElement: string) => {
         if (erVedtakFraFagsystemet(valgtElement)) {
-            const erInternKlagebehandlingId = isNaN(Number(valgtElement));
+            const erInternKlagebehandlingId = valgtElement.startsWith('internId');
 
             if (erInternKlagebehandlingId) {
                 settOppdaterteVurderinger((prevState) => ({
                     ...prevState,
                     påklagetVedtak: {
-                        internKlagebehandlingId: valgtElement,
+                        internKlagebehandlingId: valgtElement.replace('internId', ''),
                         påklagetVedtakstype: PåklagetVedtakstype.AVVIST_KLAGE,
                     },
                 }));
@@ -118,7 +118,7 @@ export const VedtakSelect: React.FC<IProps> = ({
                 {klagebehandlingsresultater
                     .sort(sorterVedtakstidspunktKlageResultatDesc)
                     .map((klager, index) => (
-                        <option key={index} value={klager.id}>
+                        <option key={index} value={'internId' + klager.id}>
                             {klageresultatTilVisningstekst(klager)}
                         </option>
                     ))}


### PR DESCRIPTION
Meldt i teams hvor det er problemer med å lagre formkrav.
Det viser seg at bug'n gjelder for klage på tilbakekreving. Tidligere if-sjekk antok at alle uuid's var en intern klagebehandling, men tilbakekreving har uuid som ekstern id, og det ble derfor feil. Retter dette ved å markere intern-id'er mer spesifikt. Dette er en midlertidig løsning for saksbehandlere, men dette burde skrives om til at value i kombobox inneholder mer typet informasjon.