### PR TITLE
Endre endepunkt for å lagre vurdering

### DIFF
--- a/src/frontend/App/hooks/useHentVurderinger.ts
+++ b/src/frontend/App/hooks/useHentVurderinger.ts
@@ -49,7 +49,7 @@ export const useHentVurderinger = (): {
         settFeilVedLagring('');
         return axiosRequest<IVurdering, IVurdering>({
             method: 'POST',
-            url: `/familie-klage/api/vurdering`,
+            url: `/familie-klage/api/vurdering/lagre-og-oppdater-steg`,
             data: vurdering,
         }).then((respons: RessursSuksess<IVurdering> | RessursFeilet) => {
             if (respons.status === RessursStatus.SUKSESS) {


### PR DESCRIPTION
I [denne](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24788) oppgaven skal det lages et nytt endepunkt for å kunne mellomlagre vurdering, uten validering og oppdatering av steg.

- Endrer det eksisterende endepunktet slik at det er lettere å skille mellom sideeffektene til endepunktene når man ser på URL'en

[Tilhørende PR i backend](https://github.com/navikt/familie-klage/pull/635)