### PR TITLE
Ikke sett tekstfelt til null i stedet for undefined når det er tom streng

### DIFF
--- a/src/frontend/Komponenter/Behandling/Vurdering/VurderingRedigeringsmodusBaks/InnstillingTilNavKlageinstans.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/VurderingRedigeringsmodusBaks/InnstillingTilNavKlageinstans.tsx
@@ -4,19 +4,16 @@ import { LesMerOmInnstilling } from '../InnstillingTilNavKlageinstans/LesMerOmIn
 import { Accordion, Box, Heading } from '@navikt/ds-react';
 import { InnstillingTilNavKlageinstansAvsnitt } from './InnstillingTilNavKlageinstansAvsnitt';
 import { Tekstfelt } from './Tekstfelt';
+import { VurderingAccordionFelter } from './felttyper';
 
-export interface AccordionTilstand {
-    dokumentasjonOgUtredning: boolean;
-    spørsmåletISaken: boolean;
-    aktuelleRettskilder: boolean;
-    klagersAnførsler: boolean;
-    vurderingAvKlagen: boolean;
-}
+export type AccordionTilstand = {
+    [key in keyof VurderingAccordionFelter]: boolean;
+};
 
 interface Props {
     behandling: Behandling;
     accordionTilstand: AccordionTilstand;
-    toggleAccordionTilstand: (feltnavn: keyof AccordionTilstand) => void;
+    toggleAccordionTilstand: (feltnavn: keyof VurderingAccordionFelter) => void;
 }
 
 export const InnstillingTilNavKlageinstans = ({

--- a/src/frontend/Komponenter/Behandling/Vurdering/VurderingRedigeringsmodusBaks/InnstillingTilNavKlageinstansAvsnitt.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/VurderingRedigeringsmodusBaks/InnstillingTilNavKlageinstansAvsnitt.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { Accordion } from '@navikt/ds-react';
 import { Tekstfelt } from './Tekstfelt';
-import { AccordionTilstand } from './InnstillingTilNavKlageinstans';
+import { VurderingAccordionFelter } from './felttyper';
 
 interface Props {
     visningsnavn: string;
-    feltnavn: keyof AccordionTilstand;
+    feltnavn: keyof VurderingAccordionFelter;
     åpen: boolean;
-    toggleÅpen: (feltnavn: keyof AccordionTilstand) => void;
+    toggleÅpen: (feltnavn: keyof VurderingAccordionFelter) => void;
 }
 
 export const InnstillingTilNavKlageinstansAvsnitt = ({

--- a/src/frontend/Komponenter/Behandling/Vurdering/VurderingRedigeringsmodusBaks/Nedtrekksliste.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/VurderingRedigeringsmodusBaks/Nedtrekksliste.tsx
@@ -2,14 +2,12 @@ import * as React from 'react';
 import { FC } from 'react';
 import { Box, Heading, Select } from '@navikt/ds-react';
 import { Controller, useFormContext } from 'react-hook-form';
-import { IVurdering } from '../vurderingValg';
 import { useApp } from '../../../../App/context/AppContext';
-
-type VurderingNedtrekksliste = Pick<IVurdering, 'vedtak' | 'hjemmel' | 'årsak'>;
+import { VurderingNedtrekkslisteFelter } from './felttyper';
 
 interface NedtrekkslisteProps {
     visningsnavn: string;
-    feltnavn: keyof VurderingNedtrekksliste;
+    feltnavn: keyof VurderingNedtrekkslisteFelter;
     alternativer: Record<string, string>;
 }
 

--- a/src/frontend/Komponenter/Behandling/Vurdering/VurderingRedigeringsmodusBaks/Nedtrekksliste.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/VurderingRedigeringsmodusBaks/Nedtrekksliste.tsx
@@ -41,7 +41,7 @@ export const Nedtrekksliste: FC<NedtrekkslisteProps> = ({
                             onBlur={field.onBlur}
                             onChange={({ target: { name, value } }) => {
                                 settIkkePersistertKomponent(name);
-                                setValue(field.name, value === '' ? undefined : value);
+                                setValue(field.name, value === '' ? null : value);
                             }}
                             error={visFeilmelding && fieldState.error?.message}
                             readOnly={formState.isSubmitting}

--- a/src/frontend/Komponenter/Behandling/Vurdering/VurderingRedigeringsmodusBaks/Nedtrekksliste.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/VurderingRedigeringsmodusBaks/Nedtrekksliste.tsx
@@ -39,7 +39,7 @@ export const Nedtrekksliste: FC<NedtrekkslisteProps> = ({
                             onBlur={field.onBlur}
                             onChange={({ target: { name, value } }) => {
                                 settIkkePersistertKomponent(name);
-                                field.onChange(value === '' ? null : value);
+                                field.onChange(value);
                             }}
                             error={visFeilmelding && fieldState.error?.message}
                             readOnly={formState.isSubmitting}

--- a/src/frontend/Komponenter/Behandling/Vurdering/VurderingRedigeringsmodusBaks/Nedtrekksliste.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/VurderingRedigeringsmodusBaks/Nedtrekksliste.tsx
@@ -18,7 +18,7 @@ export const Nedtrekksliste: FC<NedtrekkslisteProps> = ({
     feltnavn,
     alternativer,
 }) => {
-    const { control, formState, setValue } = useFormContext();
+    const { control, formState } = useFormContext();
     const { settIkkePersistertKomponent } = useApp();
     return (
         <Box maxWidth="18rem">
@@ -41,7 +41,7 @@ export const Nedtrekksliste: FC<NedtrekkslisteProps> = ({
                             onBlur={field.onBlur}
                             onChange={({ target: { name, value } }) => {
                                 settIkkePersistertKomponent(name);
-                                setValue(field.name, value === '' ? null : value);
+                                field.onChange(value === '' ? null : value);
                             }}
                             error={visFeilmelding && fieldState.error?.message}
                             readOnly={formState.isSubmitting}

--- a/src/frontend/Komponenter/Behandling/Vurdering/VurderingRedigeringsmodusBaks/Tekstfelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/VurderingRedigeringsmodusBaks/Tekstfelt.tsx
@@ -1,24 +1,12 @@
 import { Textarea } from '@navikt/ds-react';
 import { Controller, useFormContext } from 'react-hook-form';
 import React, { FC } from 'react';
-import { IVurdering } from '../vurderingValg';
 import { useApp } from '../../../../App/context/AppContext';
-
-export type VurderingTekstfelt = Pick<
-    IVurdering,
-    | 'begrunnelseOmgjøring'
-    | 'innstillingKlageinstans'
-    | 'dokumentasjonOgUtredning'
-    | 'spørsmåletISaken'
-    | 'aktuelleRettskilder'
-    | 'klagersAnførsler'
-    | 'vurderingAvKlagen'
-    | 'interntNotat'
->;
+import { VurderingTekstfeltFelter } from './felttyper';
 
 interface TekstfeltProps {
     visningsnavn: string;
-    feltnavn: keyof VurderingTekstfelt;
+    feltnavn: keyof VurderingTekstfeltFelter;
     frivillig?: boolean;
 }
 

--- a/src/frontend/Komponenter/Behandling/Vurdering/VurderingRedigeringsmodusBaks/Tekstfelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/VurderingRedigeringsmodusBaks/Tekstfelt.tsx
@@ -23,7 +23,7 @@ interface TekstfeltProps {
 }
 
 export const Tekstfelt: FC<TekstfeltProps> = ({ visningsnavn, feltnavn, frivillig }) => {
-    const { control, formState, setValue } = useFormContext();
+    const { control, formState } = useFormContext();
     const { settIkkePersistertKomponent } = useApp();
     return (
         <Controller
@@ -42,7 +42,7 @@ export const Tekstfelt: FC<TekstfeltProps> = ({ visningsnavn, feltnavn, frivilli
                         onBlur={field.onBlur}
                         onChange={({ target: { name, value } }) => {
                             settIkkePersistertKomponent(name);
-                            setValue(field.name, value === '' ? null : value);
+                            field.onChange(value === '' ? null : value);
                         }}
                         error={visFeilmelding && fieldState.error?.message}
                         readOnly={formState.isSubmitting}

--- a/src/frontend/Komponenter/Behandling/Vurdering/VurderingRedigeringsmodusBaks/Tekstfelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/VurderingRedigeringsmodusBaks/Tekstfelt.tsx
@@ -30,7 +30,7 @@ export const Tekstfelt: FC<TekstfeltProps> = ({ visningsnavn, feltnavn, frivilli
                         onBlur={field.onBlur}
                         onChange={({ target: { name, value } }) => {
                             settIkkePersistertKomponent(name);
-                            field.onChange(value === '' ? null : value);
+                            field.onChange(value);
                         }}
                         error={visFeilmelding && fieldState.error?.message}
                         readOnly={formState.isSubmitting}

--- a/src/frontend/Komponenter/Behandling/Vurdering/VurderingRedigeringsmodusBaks/Tekstfelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/VurderingRedigeringsmodusBaks/Tekstfelt.tsx
@@ -42,7 +42,7 @@ export const Tekstfelt: FC<TekstfeltProps> = ({ visningsnavn, feltnavn, frivilli
                         onBlur={field.onBlur}
                         onChange={({ target: { name, value } }) => {
                             settIkkePersistertKomponent(name);
-                            setValue(field.name, value === '' ? undefined : value);
+                            setValue(field.name, value === '' ? null : value);
                         }}
                         error={visFeilmelding && fieldState.error?.message}
                         readOnly={formState.isSubmitting}

--- a/src/frontend/Komponenter/Behandling/Vurdering/VurderingRedigeringsmodusBaks/felttyper.ts
+++ b/src/frontend/Komponenter/Behandling/Vurdering/VurderingRedigeringsmodusBaks/felttyper.ts
@@ -1,0 +1,24 @@
+import { VedtakValg, ÅrsakOmgjøring } from '../vurderingValg';
+import { Hjemmel } from '../hjemmel';
+
+export type VurderingSkjemaverdier = VurderingNedtrekkslisteFelter & VurderingTekstfeltFelter;
+
+export type VurderingNedtrekkslisteFelter = {
+    vedtak: VedtakValg | '';
+    årsak: ÅrsakOmgjøring | '';
+    hjemmel: Hjemmel | '';
+};
+
+export type VurderingTekstfeltFelter = {
+    begrunnelseOmgjøring: string;
+    innstillingKlageinstans: string;
+    interntNotat: string;
+} & VurderingAccordionFelter;
+
+export type VurderingAccordionFelter = {
+    dokumentasjonOgUtredning: string;
+    spørsmåletISaken: string;
+    aktuelleRettskilder: string;
+    klagersAnførsler: string;
+    vurderingAvKlagen: string;
+};

--- a/src/frontend/Komponenter/Behandling/Vurdering/vurderingValg.ts
+++ b/src/frontend/Komponenter/Behandling/Vurdering/vurderingValg.ts
@@ -3,17 +3,17 @@ import { Fagsystem } from '../../../App/typer/fagsak';
 
 export interface IVurdering {
     behandlingId: string;
-    vedtak?: VedtakValg | null;
-    årsak?: ÅrsakOmgjøring | null;
-    begrunnelseOmgjøring?: string | null;
-    hjemmel?: Hjemmel | null;
-    innstillingKlageinstans?: string | null;
-    dokumentasjonOgUtredning?: string | null;
-    spørsmåletISaken?: string | null;
-    aktuelleRettskilder?: string | null;
-    klagersAnførsler?: string | null;
-    vurderingAvKlagen?: string | null;
-    interntNotat?: string | null;
+    vedtak?: VedtakValg;
+    årsak?: ÅrsakOmgjøring;
+    begrunnelseOmgjøring?: string;
+    hjemmel?: Hjemmel;
+    innstillingKlageinstans?: string;
+    dokumentasjonOgUtredning?: string;
+    spørsmåletISaken?: string;
+    aktuelleRettskilder?: string;
+    klagersAnførsler?: string;
+    vurderingAvKlagen?: string;
+    interntNotat?: string;
 }
 
 // VEDTAK

--- a/src/frontend/Komponenter/Behandling/Vurdering/vurderingValg.ts
+++ b/src/frontend/Komponenter/Behandling/Vurdering/vurderingValg.ts
@@ -3,17 +3,17 @@ import { Fagsystem } from '../../../App/typer/fagsak';
 
 export interface IVurdering {
     behandlingId: string;
-    vedtak?: VedtakValg;
-    årsak?: ÅrsakOmgjøring;
-    begrunnelseOmgjøring?: string;
-    hjemmel?: Hjemmel;
-    innstillingKlageinstans?: string;
-    dokumentasjonOgUtredning?: string;
-    spørsmåletISaken?: string;
-    aktuelleRettskilder?: string;
-    klagersAnførsler?: string;
-    vurderingAvKlagen?: string;
-    interntNotat?: string;
+    vedtak?: VedtakValg | null;
+    årsak?: ÅrsakOmgjøring | null;
+    begrunnelseOmgjøring?: string | null;
+    hjemmel?: Hjemmel | null;
+    innstillingKlageinstans?: string | null;
+    dokumentasjonOgUtredning?: string | null;
+    spørsmåletISaken?: string | null;
+    aktuelleRettskilder?: string | null;
+    klagersAnførsler?: string | null;
+    vurderingAvKlagen?: string | null;
+    interntNotat?: string | null;
 }
 
 // VEDTAK


### PR DESCRIPTION
Fikser en bug som skyldes at tekstfeltet settes til `undefined` når det er tom string, som gjør at react-hook-form setter feltet til default. Endrer slik at det heller settes til `null`