### PR TITLE
NAV-24862: Fjerner "visbrevmottakerBaks" fra toggles.ts da det ble glemt når toggelen ble fjernet.

### DIFF
--- a/src/frontend/App/context/toggles.ts
+++ b/src/frontend/App/context/toggles.ts
@@ -7,7 +7,6 @@ export enum ToggleName {
     skalKunneVelgePåklagetVedtakFraInfotrygd = 'familie.klage.infotrygd-vedtak',
 
     // Release-toggles
-    visBrevmottakerBaks = 'familie-klage.vis-brevmottaker-baks',
     leggTilBrevmottakerBaks = 'familie-klage.legg-til-brevmottaker-baks',
     kanMellomlagreVurdering = 'familie-klage.kan-mellomlagre-vurdering',
 }


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24862

Toggelen er allerede fjernet, men glemte å fjerne innslaget fra `toggles.ts` filen. 