### PR TITLE
Fiks bug i henting av brevmottakere

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/Brev.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Brev.tsx
@@ -115,11 +115,11 @@ export const Brev: React.FC<Props> = ({ behandling }: Props) => {
                 <HGrid gap={'6'} columns={{ xl: 1, '2xl': '1fr 1.2fr' }}>
                     <VStack gap={'6'}>
                         {brevRessurs.status === RessursStatus.SUKSESS &&
-                        behandling.fagsystem !== Fagsystem.EF ? (
-                            <BaksBrevmottakerContainer behandlingId={behandling.id} />
-                        ) : (
-                            <BrevMottakere behandlingId={behandling.id} />
-                        )}
+                            (behandling.fagsystem !== Fagsystem.EF ? (
+                                <BaksBrevmottakerContainer behandlingId={behandling.id} />
+                            ) : (
+                                <BrevMottakere behandlingId={behandling.id} />
+                            ))}
                         {behandlingErRedigerbar && brevRessurs.status === RessursStatus.SUKSESS && (
                             <Button
                                 variant={'primary'}


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25013)

I #920 ble det innført en bug som endret logikken for visning, som gjorde at brevmottakere ble hentet før brevet var generert.
Legger til parentes rundt visningen, slik at ingen av komponentene blir vist før brevmottakere er lastet inn.