### PR TITLE
NAV-25176: Refaktorere eksisterende logikk i "henlegg behandling" modal slik at det blir lettere å legge til ny funksjonalitet senere, tar i bruk RHF for form-state

### DIFF
--- a/src/frontend/App/context/toggles.ts
+++ b/src/frontend/App/context/toggles.ts
@@ -10,4 +10,5 @@ export enum ToggleName {
     leggTilBrevmottakerBaks = 'familie-klage.legg-til-brevmottaker-baks',
     kanMellomlagreVurdering = 'familie-klage.kan-mellomlagre-vurdering',
     skalKunneEndreBehandlendeEnhetBaks = 'familie-klage.skal-kunne-endre-behandlende-enhet-baks',
+    brukNyHenleggBehandlingModal = 'familie-klage.bruk-ny-henlegg-behandling-modal',
 }

--- a/src/frontend/App/typer/personopplysninger.ts
+++ b/src/frontend/App/typer/personopplysninger.ts
@@ -1,3 +1,5 @@
+import { erEtterDagensDato } from '../utils/dato';
+
 export interface IPersonopplysninger {
     personIdent: string;
     navn: string;
@@ -10,6 +12,18 @@ export interface IPersonopplysninger {
     fullmakt: IFullmakt[];
     navEnhet: string;
     vergemål: IVergemål[];
+}
+
+export function erPersonopplysningerTilknyttetFullmakt(
+    personopplysninger: IPersonopplysninger
+): boolean {
+    return personopplysninger.fullmakt.some(
+        (fullmakt) => fullmakt.gyldigTilOgMed === null || erEtterDagensDato(fullmakt.gyldigTilOgMed)
+    );
+}
+
+export function harPersonopplysningerVergemål(personopplysninger: IPersonopplysninger): boolean {
+    return personopplysninger.vergemål.length > 0;
 }
 
 export enum Kjønn {

--- a/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
@@ -10,12 +10,15 @@ import VisittkortComponent from '../../Felles/Visittkort/Visittkort';
 import { Behandling } from '../../App/typer/fagsak';
 import { IPersonopplysninger } from '../../App/typer/personopplysninger';
 import DataViewer from '../../Felles/DataViewer/DataViewer';
-import { HenleggModal } from './Henleggelse/HenleggModal';
 import ScrollToTop from '../../Felles/ScrollToTop/ScrollToTop';
 import { useSetPersonIdent } from '../../App/hooks/useSetPersonIdent';
 import { useSetValgtFagsakId } from '../../App/hooks/useSetValgtFagsakId';
 import { SettPåVent } from './SettPåVent/SettPåVent';
 import { EndreBehandlendeEnhetModal } from './EndreBehandlendeEnhet/EndreBehandlendeEnhetModal';
+import { HenleggModalNy } from './Henleggelse/HenleggModalNy';
+import { HenleggModalGammel } from './Henleggelse/HenleggModalGammel';
+import { useToggles } from '../../App/context/TogglesContext';
+import { ToggleName } from '../../App/context/toggles';
 
 const Container = styled.div`
     display: flex;
@@ -66,6 +69,7 @@ const BehandlingContent: FC<{
     useSetValgtFagsakId(behandling.fagsakId);
     useSetPersonIdent(personopplysninger.personIdent);
     const { åpenHøyremeny } = useBehandling();
+    const { toggles } = useToggles();
 
     return (
         <>
@@ -77,7 +81,17 @@ const BehandlingContent: FC<{
                     <SettPåVent behandling={behandling} />
                     <EndreBehandlendeEnhetModal behandling={behandling} />
                     <BehandlingRoutes behandling={behandling} />
-                    <HenleggModal behandling={behandling} personopplysninger={personopplysninger} />
+                    {toggles[ToggleName.brukNyHenleggBehandlingModal] ? (
+                        <HenleggModalNy
+                            behandling={behandling}
+                            personopplysninger={personopplysninger}
+                        />
+                    ) : (
+                        <HenleggModalGammel
+                            behandling={behandling}
+                            personopplysninger={personopplysninger}
+                        />
+                    )}
                 </InnholdWrapper>
                 <HøyreMenyWrapper åpenHøyremeny={åpenHøyremeny}>
                     <Høyremeny åpenHøyremeny={åpenHøyremeny} behandling={behandling} />

--- a/src/frontend/Komponenter/Behandling/Henleggelse/EHenlagtÅrsak.tsx
+++ b/src/frontend/Komponenter/Behandling/Henleggelse/EHenlagtÅrsak.tsx
@@ -1,4 +1,0 @@
-export enum EHenlagtårsak {
-    TRUKKET_TILBAKE = 'TRUKKET_TILBAKE',
-    FEILREGISTRERT = 'FEILREGISTRERT',
-}

--- a/src/frontend/Komponenter/Behandling/Henleggelse/HenlagtÅrsakFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Henleggelse/HenlagtÅrsakFelt.tsx
@@ -1,0 +1,35 @@
+import { Radio, RadioGroup } from '@navikt/ds-react';
+import { Henlagtårsak } from './Henlagtårsak';
+import React from 'react';
+import { useController, useFormContext } from 'react-hook-form';
+import { CustomFormErrors, Feltnavn } from './HenleggModalNy';
+
+export function HenlagtÅrsakFelt() {
+    const { clearErrors } = useFormContext();
+
+    const { field, fieldState, formState } = useController({
+        name: Feltnavn.HENLAGT_ÅRSAK,
+        rules: {
+            validate: (value) => (value === null ? 'Du må velge en henleggesesårsak.' : undefined),
+        },
+    });
+
+    return (
+        <RadioGroup
+            legend={'Velg henleggelsesårsak'}
+            name={field.name}
+            value={field.value}
+            ref={field.ref}
+            onChange={(value) => {
+                clearErrors(CustomFormErrors.onSubmitError.id);
+                field.onChange(value);
+            }}
+            onBlur={field.onBlur}
+            error={fieldState.error?.message}
+            readOnly={formState.isSubmitting}
+        >
+            <Radio value={Henlagtårsak.TRUKKET_TILBAKE}>Trukket tilbake</Radio>
+            <Radio value={Henlagtårsak.FEILREGISTRERT}>Feilregistrert</Radio>
+        </RadioGroup>
+    );
+}

--- a/src/frontend/Komponenter/Behandling/Henleggelse/Henlagtårsak.ts
+++ b/src/frontend/Komponenter/Behandling/Henleggelse/Henlagtårsak.ts
@@ -1,0 +1,8 @@
+export enum Henlagtårsak {
+    TRUKKET_TILBAKE = 'TRUKKET_TILBAKE',
+    FEILREGISTRERT = 'FEILREGISTRERT',
+}
+
+export function erHenlagtÅrsakTrukketTilbake(henlagtÅrsak: Henlagtårsak | null) {
+    return henlagtÅrsak === Henlagtårsak.TRUKKET_TILBAKE;
+}

--- a/src/frontend/Komponenter/Behandling/Henleggelse/HenleggModalGammel.tsx
+++ b/src/frontend/Komponenter/Behandling/Henleggelse/HenleggModalGammel.tsx
@@ -5,7 +5,7 @@ import { Behandling } from '../../../App/typer/fagsak';
 import { useApp } from '../../../App/context/AppContext';
 import { useNavigate } from 'react-router-dom';
 import { EToast } from '../../../App/typer/toast';
-import { EHenlagtårsak } from './EHenlagtÅrsak';
+import { Henlagtårsak } from './Henlagtårsak';
 import styled from 'styled-components';
 import { Alert, Radio, RadioGroup, VStack } from '@navikt/ds-react';
 import { ModalWrapper } from '../../../Felles/Modal/ModalWrapper';
@@ -23,7 +23,7 @@ const HorizontalDivider = styled.div`
     border-bottom: 2px solid ${ABorderSubtle};
 `;
 
-export const HenleggModal: FC<{
+export const HenleggModalGammel: FC<{
     behandling: Behandling;
     personopplysninger: IPersonopplysninger;
 }> = ({ behandling, personopplysninger }) => {
@@ -33,7 +33,7 @@ export const HenleggModal: FC<{
     const vergemål = personopplysninger.vergemål;
     const { axiosRequest, settToast } = useApp();
     const navigate = useNavigate();
-    const [henlagtårsak, settHenlagtårsak] = useState<EHenlagtårsak>();
+    const [henlagtårsak, settHenlagtårsak] = useState<Henlagtårsak>();
     const [henleggerBehandling, settHenleggerBehandling] = useState<boolean>(false);
     const [feilmelding, settFeilmelding] = useState<string>();
     const [harHuketAvSendBrev, settHarHuketAvSendBrev] = useState<boolean>(true);
@@ -49,11 +49,11 @@ export const HenleggModal: FC<{
         }
         settHenleggerBehandling(true);
 
-        axiosRequest<string, { årsak: EHenlagtårsak; skalSendeHenleggelsesbrev: boolean }>({
+        axiosRequest<string, { årsak: Henlagtårsak; skalSendeHenleggelsesbrev: boolean }>({
             method: 'POST',
             url: `/familie-klage/api/behandling/${behandling.id}/henlegg`,
             data: {
-                årsak: henlagtårsak as EHenlagtårsak,
+                årsak: henlagtårsak as Henlagtårsak,
                 skalSendeHenleggelsesbrev: harValgtSendBrevOgSkalViseFramValg,
             },
         })
@@ -99,7 +99,7 @@ export const HenleggModal: FC<{
     const tilknyttetFullmakt = fullmakter.some(
         (fullmakt) => fullmakt.gyldigTilOgMed === null || erEtterDagensDato(fullmakt.gyldigTilOgMed)
     );
-    const henlagtårsakTrukketTilbake = henlagtårsak === EHenlagtårsak.TRUKKET_TILBAKE;
+    const henlagtårsakTrukketTilbake = henlagtårsak === Henlagtårsak.TRUKKET_TILBAKE;
 
     const harVergemål = vergemål.length > 0;
 
@@ -123,12 +123,9 @@ export const HenleggModal: FC<{
             ariaLabel={'Velg årsak til henleggelse av behandlingen'}
         >
             <VStack gap="4">
-                <RadioGroup
-                    legend={''}
-                    onChange={(årsak: EHenlagtårsak) => settHenlagtårsak(årsak)}
-                >
-                    <Radio value={EHenlagtårsak.TRUKKET_TILBAKE}>Trukket tilbake</Radio>
-                    <Radio value={EHenlagtårsak.FEILREGISTRERT}>Feilregistrert</Radio>
+                <RadioGroup legend={''} onChange={(årsak: Henlagtårsak) => settHenlagtårsak(årsak)}>
+                    <Radio value={Henlagtårsak.TRUKKET_TILBAKE}>Trukket tilbake</Radio>
+                    <Radio value={Henlagtårsak.FEILREGISTRERT}>Feilregistrert</Radio>
                 </RadioGroup>
                 {skalViseTilleggsvalg && (
                     <>

--- a/src/frontend/Komponenter/Behandling/Henleggelse/HenleggModalNy.tsx
+++ b/src/frontend/Komponenter/Behandling/Henleggelse/HenleggModalNy.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import { useBehandling } from '../../../App/context/BehandlingContext';
+import { Behandling } from '../../../App/typer/fagsak';
+import { useApp } from '../../../App/context/AppContext';
+import { useNavigate } from 'react-router-dom';
+import { EToast } from '../../../App/typer/toast';
+import { Henlagtårsak, erHenlagtÅrsakTrukketTilbake } from './Henlagtårsak';
+import { Alert, Box, Button, Fieldset, Modal, VStack } from '@navikt/ds-react';
+import { Link } from '@navikt/ds-react';
+import { base64toBlob, åpnePdfIEgenTab } from '../../../App/utils/utils';
+import {
+    erPersonopplysningerTilknyttetFullmakt,
+    harPersonopplysningerVergemål,
+    IPersonopplysninger,
+} from '../../../App/typer/personopplysninger';
+import { FieldErrors, FormProvider, useForm } from 'react-hook-form';
+import { HenlagtÅrsakFelt } from './HenlagtÅrsakFelt';
+import { SendTrukketKlageBrevFelt } from './SendTrukketKlageBrevFelt';
+import { useHentBrev } from './useHentBrev';
+import { useHenleggBehandling } from './useHenleggBehandling';
+import { LinkIcon } from '@navikt/aksel-icons';
+
+export const CustomFormErrors: Record<
+    'onSubmitError' | 'visBrevError',
+    {
+        id: `root.${string}`;
+        lookup: (errors: FieldErrors<FormValues>) => string | undefined;
+    }
+> = {
+    onSubmitError: {
+        id: 'root.onSubmitError',
+        lookup: (errors) => errors?.root?.onSubmitError?.message,
+    },
+    visBrevError: {
+        id: 'root.visBrevError',
+        lookup: (errors) => errors?.root?.visBrevError?.message,
+    },
+};
+
+interface FormValues {
+    [Feltnavn.HENLAGT_ÅRSAK]: Henlagtårsak | null;
+    [Feltnavn.SEND_BREV_OM_TRUKKET_KLAGE]: boolean | null;
+}
+
+interface ValidFormValues extends FormValues {
+    [Feltnavn.HENLAGT_ÅRSAK]: Henlagtårsak;
+}
+
+export enum Feltnavn {
+    HENLAGT_ÅRSAK = 'henlagtÅrsak',
+    SEND_BREV_OM_TRUKKET_KLAGE = 'sendBrevOmTrukketKlage',
+}
+
+interface Props {
+    behandling: Behandling;
+    personopplysninger: IPersonopplysninger;
+}
+
+export function HenleggModalNy({ behandling, personopplysninger }: Props) {
+    const navigate = useNavigate();
+    const { visHenleggModal, settVisHenleggModal } = useBehandling();
+    const { settToast } = useApp();
+    const { henleggBhandling } = useHenleggBehandling();
+    const { hentBrev } = useHentBrev();
+
+    const form = useForm<FormValues, unknown, ValidFormValues>({
+        mode: 'onChange',
+        defaultValues: {
+            [Feltnavn.HENLAGT_ÅRSAK]: null,
+            [Feltnavn.SEND_BREV_OM_TRUKKET_KLAGE]: null,
+        },
+    });
+
+    const {
+        handleSubmit,
+        reset,
+        formState: { isSubmitting, errors },
+        watch,
+        setError,
+    } = form;
+
+    async function onSubmit(values: ValidFormValues): Promise<Awaited<void>> {
+        return henleggBhandling(behandling.id, values.henlagtÅrsak, values.sendBrevOmTrukketKlage)
+            .then(() => {
+                settVisHenleggModal(false);
+                settToast(EToast.BEHANDLING_HENLAGT);
+                navigate(`/behandling/${behandling.id}/resultat`);
+            })
+            .catch((error: Error) => {
+                setError(CustomFormErrors.onSubmitError.id, { message: error.message });
+            });
+    }
+
+    async function hentOgÅpneBrevINyFane(): Promise<Awaited<void>> {
+        return hentBrev(behandling.id)
+            .then((data) => {
+                åpnePdfIEgenTab(
+                    base64toBlob(data, 'application/pdf'),
+                    'Forhåndsvisning av trukket søknadsbrev'
+                );
+            })
+            .catch((error: Error) =>
+                setError(CustomFormErrors.visBrevError.id, { message: error.message })
+            );
+    }
+
+    function lukkModal() {
+        settVisHenleggModal(false);
+        reset();
+    }
+
+    const erHenlagtÅrsakTrukketTilbakeValgt = erHenlagtÅrsakTrukketTilbake(
+        watch(Feltnavn.HENLAGT_ÅRSAK)
+    );
+
+    const erTilknyttetFullmakt = erPersonopplysningerTilknyttetFullmakt(personopplysninger);
+    const harVergemål = harPersonopplysningerVergemål(personopplysninger);
+
+    const skalViseTilleggsvalg =
+        !harVergemål && !erTilknyttetFullmakt && erHenlagtÅrsakTrukketTilbakeValgt;
+
+    const onSubmitError = CustomFormErrors.onSubmitError.lookup(errors);
+    const visBrevError = CustomFormErrors.visBrevError.lookup(errors);
+
+    return (
+        <Modal
+            header={{ heading: 'Henlegg behandling', closeButton: true }}
+            open={visHenleggModal}
+            onClose={lukkModal}
+            aria-label={'Velg årsak til henleggelse av behandlingen'}
+            width={'medium'}
+        >
+            <FormProvider {...form}>
+                <form onSubmit={handleSubmit(onSubmit)}>
+                    <Modal.Body>
+                        <VStack gap={'4'}>
+                            <Fieldset legend={'Henlegg behandling'} hideLegend={true}>
+                                <HenlagtÅrsakFelt />
+                                {skalViseTilleggsvalg && <SendTrukketKlageBrevFelt />}
+                            </Fieldset>
+                            {skalViseTilleggsvalg && (
+                                <Box paddingBlock={'space-12'}>
+                                    <Link onClick={hentOgÅpneBrevINyFane} href={'#'}>
+                                        Forhåndsvis brev
+                                        <LinkIcon title={'Forhåndsvis brev'} fontSize={'1.5rem'} />
+                                    </Link>
+                                </Box>
+                            )}
+                            {visBrevError && <Alert variant={'error'}>{visBrevError}</Alert>}
+                            {onSubmitError && <Alert variant={'error'}>{onSubmitError}</Alert>}
+                            {harVergemål && erHenlagtÅrsakTrukketTilbakeValgt && (
+                                <Alert variant={'warning'}>
+                                    Verge registrert på bruker. Brev om trukket klage må sendes
+                                    manuelt.
+                                </Alert>
+                            )}
+                            {erTilknyttetFullmakt && erHenlagtÅrsakTrukketTilbakeValgt && (
+                                <Alert variant={'warning'}>
+                                    Fullmakt registrert på bruker. Brev om trukket klage må sendes
+                                    manuelt.
+                                </Alert>
+                            )}
+                        </VStack>
+                    </Modal.Body>
+                    <Modal.Footer>
+                        <Button
+                            variant={'primary'}
+                            type={'submit'}
+                            disabled={isSubmitting}
+                            loading={isSubmitting}
+                        >
+                            Henlegg
+                        </Button>
+                        <Button variant={'tertiary'} onClick={lukkModal} disabled={isSubmitting}>
+                            Avbryt
+                        </Button>
+                    </Modal.Footer>
+                </form>
+            </FormProvider>
+        </Modal>
+    );
+}

--- a/src/frontend/Komponenter/Behandling/Henleggelse/SendTrukketKlageBrevFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Henleggelse/SendTrukketKlageBrevFelt.tsx
@@ -1,0 +1,38 @@
+import { Radio, RadioGroup, Stack } from '@navikt/ds-react';
+import React from 'react';
+import { useController, useFormContext } from 'react-hook-form';
+import { CustomFormErrors, Feltnavn } from './HenleggModalNy';
+
+export function SendTrukketKlageBrevFelt() {
+    const { clearErrors } = useFormContext();
+
+    const { field, fieldState, formState } = useController({
+        name: Feltnavn.SEND_BREV_OM_TRUKKET_KLAGE,
+        shouldUnregister: true,
+        rules: {
+            validate: (value) =>
+                value === null ? 'Velg hvorvidt brev om trukket klage skal sendes.' : undefined,
+        },
+    });
+
+    return (
+        <RadioGroup
+            legend={'Send brev om trukket klage'}
+            name={field.name}
+            value={field.value}
+            ref={field.ref}
+            onBlur={field.onBlur}
+            onChange={(value) => {
+                clearErrors(CustomFormErrors.onSubmitError.id);
+                field.onChange(value);
+            }}
+            error={fieldState.error?.message}
+            readOnly={formState.isSubmitting}
+        >
+            <Stack gap={'0 6'} direction={{ xs: 'column', sm: 'row' }} wrap={false}>
+                <Radio value={true}>Ja</Radio>
+                <Radio value={false}>Nei</Radio>
+            </Stack>
+        </RadioGroup>
+    );
+}

--- a/src/frontend/Komponenter/Behandling/Henleggelse/useHenleggBehandling.ts
+++ b/src/frontend/Komponenter/Behandling/Henleggelse/useHenleggBehandling.ts
@@ -1,0 +1,39 @@
+import { Henlagtårsak } from './Henlagtårsak';
+import { RessursFeilet, RessursStatus, RessursSuksess } from '../../../App/typer/ressurs';
+import { useApp } from '../../../App/context/AppContext';
+import { useBehandling } from '../../../App/context/BehandlingContext';
+
+interface HenleggBehandlingDto {
+    årsak: Henlagtårsak;
+    skalSendeHenleggelsesbrev: boolean;
+}
+
+export function useHenleggBehandling() {
+    const { axiosRequest } = useApp();
+    const { hentBehandling, hentBehandlingshistorikk } = useBehandling();
+
+    async function henleggBhandling(
+        behandlingId: string,
+        henlagtÅrsak: Henlagtårsak,
+        sendBrevOmTrukketKlage: boolean | null
+    ): Promise<Awaited<void>> {
+        return axiosRequest<void, HenleggBehandlingDto>({
+            method: 'POST',
+            url: `/familie-klage/api/behandling/${behandlingId}/henlegg`,
+            data: {
+                årsak: henlagtÅrsak,
+                skalSendeHenleggelsesbrev: sendBrevOmTrukketKlage ?? false,
+            },
+        }).then((respons: RessursSuksess<void> | RessursFeilet) => {
+            if (respons.status === RessursStatus.SUKSESS) {
+                hentBehandling.rerun();
+                hentBehandlingshistorikk.rerun();
+                return Promise.resolve();
+            } else {
+                return Promise.reject(new Error(respons.frontendFeilmelding));
+            }
+        });
+    }
+
+    return { henleggBhandling };
+}

--- a/src/frontend/Komponenter/Behandling/Henleggelse/useHentBrev.ts
+++ b/src/frontend/Komponenter/Behandling/Henleggelse/useHentBrev.ts
@@ -1,0 +1,21 @@
+import { RessursFeilet, RessursStatus, RessursSuksess } from '../../../App/typer/ressurs';
+import { useApp } from '../../../App/context/AppContext';
+
+export function useHentBrev() {
+    const { axiosRequest } = useApp();
+
+    async function hentBrev(behandlingId: string): Promise<Awaited<string>> {
+        return axiosRequest<string, void>({
+            method: 'GET',
+            url: `/familie-klage/api/behandling/${behandlingId}/henlegg/brev/forhandsvisning`,
+        }).then((respons: RessursSuksess<string> | RessursFeilet) => {
+            if (respons.status === RessursStatus.SUKSESS) {
+                return Promise.resolve(respons.data);
+            } else {
+                return Promise.reject(new Error(respons.frontendFeilmelding));
+            }
+        });
+    }
+
+    return { hentBrev };
+}


### PR DESCRIPTION
Favro: [NAV-25176](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25176)

Refaktorer eksisterende logikk slik at det blir lettere å utvide med ny funksjonalitet i [NAV-25011](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25011), her ønsker vi å legge til mulighet for å legge til manuell brevmottaker for BAKS

Tar i bruk [RHF](https://react-hook-form.com/) for å håndtere form-state.

På sikt burde man også heller gå over til [react-query](https://tanstack.com/query/latest/docs/framework/react/overview) for å håndtere server-state fra nettverkskallene, men det får bli en annen gang. 

Relatert backend PR: https://github.com/navikt/familie-klage/pull/657
Toggle: https://teamfamilie-unleash-web.iap.nav.cloud.nais.io/projects/default/features/familie-klage.bruk-ny-henlegg-behandling-modal

Når man fyller ut:
<img width="524" alt="image" src="https://github.com/user-attachments/assets/74cdecf0-6265-4142-9fb3-f7bf12d36815" />

Når man får feilmelding ved feil i formet:
<img width="524" alt="image" src="https://github.com/user-attachments/assets/beacbb13-3763-499b-9dac-048d7a9df2bc" />

Når noe går galt ved submit:
<img width="524" alt="image" src="https://github.com/user-attachments/assets/cf59ca8c-ec73-4925-9c1f-fb8df9d6e77e" />

Når man submitter:
<img width="524" alt="image" src="https://github.com/user-attachments/assets/cc99b3f4-0c78-4ab7-a3eb-e1aece58058f" />

Feil ved forhåndsvisning av brev:
<img width="524" alt="image" src="https://github.com/user-attachments/assets/e7730645-1e7a-4355-aa5c-523224d51699" />


