### PR TITLE
Nav 25011 refaktorer brevmottaker felter

### DIFF
--- a/src/frontend/Felles/Landvelger/EøsLandvelger.tsx
+++ b/src/frontend/Felles/Landvelger/EøsLandvelger.tsx
@@ -9,7 +9,10 @@ type Props = {
     label: React.ReactNode;
 } & Omit<ComboboxProps, 'options'>;
 
+const DEFAULT_COMBOBOX_OPTION: ComboboxOption = { value: '', label: '-- Velg land --' };
+
 const eøsLand: ComboboxOption[] = [
+    DEFAULT_COMBOBOX_OPTION,
     { value: EøsLandkode.BE, label: 'Belgia' },
     { value: EøsLandkode.BG, label: 'Bulgaria' },
     { value: EøsLandkode.DK, label: 'Danmark' },
@@ -58,7 +61,7 @@ export function EøsLandvelger(props: Props) {
             onToggleSelected={(option, isSelected) => {
                 const newOption = eøsLand.find((opt) => opt.value === option);
                 if (newOption === selectedOption || newOption == undefined) {
-                    setSelectedOption(undefined);
+                    setSelectedOption(DEFAULT_COMBOBOX_OPTION);
                 } else {
                     setSelectedOption(newOption);
                 }

--- a/src/frontend/Felles/Landvelger/landkode.ts
+++ b/src/frontend/Felles/Landvelger/landkode.ts
@@ -34,10 +34,12 @@ export enum EøsLandkode {
     AT = 'AT',
 }
 
-export function erEøsLandkode(eøsLandkode: EøsLandkode | string) {
+export function erEøsLandkode(eøsLandkode: EøsLandkode | string): eøsLandkode is EøsLandkode {
     return Object.values(EøsLandkode).includes(eøsLandkode as EøsLandkode);
 }
 
-export function erUtanlandskEøsLandkode(eøsLandkode: EøsLandkode | string) {
+export function erUtenlandskEøsLandkode(
+    eøsLandkode: EøsLandkode | string
+): eøsLandkode is EøsLandkode {
     return erEøsLandkode(eøsLandkode) && eøsLandkode !== EøsLandkode.NO;
 }

--- a/src/frontend/Felles/Landvelger/landkode.ts
+++ b/src/frontend/Felles/Landvelger/landkode.ts
@@ -31,3 +31,8 @@ export enum EøsLandkode {
     HU = 'HU',
     AT = 'AT',
 }
+
+export function erUtanlandskEøsLandkode(landkode: EøsLandkode | string) {
+    const erEøsLandkode = Object.values(landkode).includes(landkode);
+    return erEøsLandkode && landkode !== EøsLandkode.NO;
+}

--- a/src/frontend/Felles/Landvelger/landkode.ts
+++ b/src/frontend/Felles/Landvelger/landkode.ts
@@ -1,3 +1,5 @@
+export type BlankEøsLandkode = '';
+
 export enum EøsLandkode {
     BE = 'BE',
     BG = 'BG',
@@ -32,7 +34,10 @@ export enum EøsLandkode {
     AT = 'AT',
 }
 
-export function erUtanlandskEøsLandkode(landkode: EøsLandkode | string) {
-    const erEøsLandkode = Object.values(landkode).includes(landkode);
-    return erEøsLandkode && landkode !== EøsLandkode.NO;
+export function erEøsLandkode(eøsLandkode: EøsLandkode | string) {
+    return Object.values(EøsLandkode).includes(eøsLandkode as EøsLandkode);
+}
+
+export function erUtanlandskEøsLandkode(eøsLandkode: EøsLandkode | string) {
+    return erEøsLandkode(eøsLandkode) && eøsLandkode !== EøsLandkode.NO;
 }

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/BrevmottakerContainer.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/BrevmottakerContainer.tsx
@@ -30,7 +30,8 @@ type Props = {
 
 export function BrevmottakerContainer({ behandlingId }: Props) {
     const { axiosRequest } = useApp();
-    const { personopplysningerResponse: personopplysninger } = useBehandling();
+    const { behandlingErRedigerbar, personopplysningerResponse: personopplysninger } =
+        useBehandling();
     const { toggles } = useToggles();
 
     const [brevmottakere, settBrevmottakere] = useState<Ressurs<Brevmottakere>>(byggTomRessurs());
@@ -109,7 +110,7 @@ export function BrevmottakerContainer({ behandlingId }: Props) {
                                 brevmottakere={brevmottakerePersonUtenIdent}
                                 opprettBrevmottaker={opprettBrevmottaker}
                                 slettBrevmottaker={slettBrevmottaker}
-                                erLesevisning={false}
+                                erLesevisning={!behandlingErRedigerbar}
                             />
                         )}
                     </>

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/BrevmottakerForm.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/BrevmottakerForm.tsx
@@ -61,7 +61,7 @@ export function BrevmottakerForm({
     opprettBrevmottaker,
 }: Props) {
     const [visSubmitError, setVisSubmitError] = useState<boolean>(false);
-    const form = useForm<BrevmottakerFormValues>({ mode: 'onChange', defaultValues });
+    const form = useForm<BrevmottakerFormValues>({ defaultValues });
     const { formState, handleSubmit, watch } = form;
 
     const landkode = watch(BrevmottakerFeltnavn.LANDKODE);

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/BrevmottakerForm.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/BrevmottakerForm.tsx
@@ -7,7 +7,7 @@ import { Adresselinje1Felt } from './felt/Adresselinje1Felt';
 import { PostnummerFelt } from './felt/PostnummerFelt';
 import { PoststedFelt } from './felt/PoststedFelt';
 import { Alert, Button, Heading, HStack, VStack } from '@navikt/ds-react';
-import { EøsLandkode } from '../../../../../../Felles/Landvelger/landkode';
+import { erUtanlandskEøsLandkode, EøsLandkode } from '../../../../../../Felles/Landvelger/landkode';
 import { IPersonopplysninger } from '../../../../../../App/typer/personopplysninger';
 import { MottakerRolle } from '../../../mottakerRolle';
 import { BrevmottakerPersonUtenIdent } from '../../../brevmottaker';
@@ -64,10 +64,6 @@ export function BrevmottakerForm({
     const form = useForm<BrevmottakerFormValues>({ defaultValues });
     const { formState, handleSubmit, watch } = form;
 
-    const landkode = watch(BrevmottakerFeltnavn.LANDKODE);
-    const erLandValgt = landkode !== '';
-    const erUtenlandskAdresseValgt = erLandValgt && landkode !== EøsLandkode.NO;
-
     async function onSubmit(brevmottakerFormValues: BrevmottakerFormValues) {
         setVisSubmitError(false);
         const erSuksess = await opprettBrevmottaker(
@@ -79,6 +75,10 @@ export function BrevmottakerForm({
             setVisSubmitError(true);
         }
     }
+
+    const landkode = watch(BrevmottakerFeltnavn.LANDKODE);
+    const erLandValgt = landkode !== '';
+    const erUtenlandskLandkode = erUtanlandskEøsLandkode(landkode);
 
     return (
         <FormProvider {...form}>
@@ -101,7 +101,7 @@ export function BrevmottakerForm({
                             <NavnFelt erLesevisning={erLesevisning} />
                             <Adresselinje1Felt erLesevisning={erLesevisning} />
                             <Adresselinje2Felt erLesevisning={erLesevisning} />
-                            {!erUtenlandskAdresseValgt && (
+                            {!erUtenlandskLandkode && (
                                 <>
                                     <PostnummerFelt erLesevisning={erLesevisning} />
                                     <PoststedFelt erLesevisning={erLesevisning} />

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/BrevmottakerForm.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/BrevmottakerForm.tsx
@@ -7,9 +7,13 @@ import { Adresselinje1Felt } from './felt/Adresselinje1Felt';
 import { PostnummerFelt } from './felt/PostnummerFelt';
 import { PoststedFelt } from './felt/PoststedFelt';
 import { Alert, Button, Heading, HStack, VStack } from '@navikt/ds-react';
-import { erUtanlandskEøsLandkode, EøsLandkode } from '../../../../../../Felles/Landvelger/landkode';
+import {
+    BlankEøsLandkode,
+    erUtanlandskEøsLandkode,
+    EøsLandkode,
+} from '../../../../../../Felles/Landvelger/landkode';
 import { IPersonopplysninger } from '../../../../../../App/typer/personopplysninger';
-import { MottakerRolle } from '../../../mottakerRolle';
+import { MottakerRolle, BlankMottakerRolle } from '../../../mottakerRolle';
 import { BrevmottakerPersonUtenIdent } from '../../../brevmottaker';
 import { lagNyBrevmottakerPersonUtenIdent, NyBrevmottaker } from '../../../nyBrevmottaker';
 import { Adresselinje2Felt } from './felt/Adresselinje2Felt';
@@ -25,8 +29,8 @@ export enum BrevmottakerFeltnavn {
 }
 
 export type BrevmottakerFormValues = {
-    [BrevmottakerFeltnavn.MOTTAKERROLLE]: MottakerRolle | '';
-    [BrevmottakerFeltnavn.LANDKODE]: EøsLandkode | '';
+    [BrevmottakerFeltnavn.MOTTAKERROLLE]: MottakerRolle | BlankMottakerRolle;
+    [BrevmottakerFeltnavn.LANDKODE]: EøsLandkode | BlankEøsLandkode;
     [BrevmottakerFeltnavn.NAVN]: string;
     [BrevmottakerFeltnavn.ADRESSELINJE1]: string;
     [BrevmottakerFeltnavn.ADRESSELINJE2]: string;
@@ -78,7 +82,7 @@ export function BrevmottakerForm({
 
     const landkode = watch(BrevmottakerFeltnavn.LANDKODE);
     const erLandValgt = landkode !== '';
-    const erUtenlandskLandkode = erUtanlandskEøsLandkode(landkode);
+    const erUtenlandskEøsLandkode = erUtanlandskEøsLandkode(landkode);
 
     return (
         <FormProvider {...form}>
@@ -101,7 +105,7 @@ export function BrevmottakerForm({
                             <NavnFelt erLesevisning={erLesevisning} />
                             <Adresselinje1Felt erLesevisning={erLesevisning} />
                             <Adresselinje2Felt erLesevisning={erLesevisning} />
-                            {!erUtenlandskLandkode && (
+                            {!erUtenlandskEøsLandkode && (
                                 <>
                                     <PostnummerFelt erLesevisning={erLesevisning} />
                                     <PoststedFelt erLesevisning={erLesevisning} />

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/BrevmottakerForm.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/BrevmottakerForm.tsx
@@ -9,11 +9,20 @@ import { PoststedFelt } from './felt/PoststedFelt';
 import { Alert, Button, Heading, HStack, VStack } from '@navikt/ds-react';
 import { EøsLandkode } from '../../../../../../Felles/Landvelger/landkode';
 import { IPersonopplysninger } from '../../../../../../App/typer/personopplysninger';
-import { BrevmottakerFeltnavn } from './felt/felttyper';
 import { MottakerRolle } from '../../../mottakerRolle';
 import { BrevmottakerPersonUtenIdent } from '../../../brevmottaker';
 import { lagNyBrevmottakerPersonUtenIdent, NyBrevmottaker } from '../../../nyBrevmottaker';
 import { Adresselinje2Felt } from './felt/Adresselinje2Felt';
+
+export enum BrevmottakerFeltnavn {
+    MOTTAKERROLLE = 'mottakerRolle',
+    LANDKODE = 'landkode',
+    NAVN = 'navn',
+    ADRESSELINJE1 = 'adresselinje1',
+    ADRESSELINJE2 = 'adresselinje2',
+    POSTNUMMER = 'postnummer',
+    POSTSTED = 'poststed',
+}
 
 export type BrevmottakerFormValues = {
     [BrevmottakerFeltnavn.MOTTAKERROLLE]: MottakerRolle | '';

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/BrevmottakerForm.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/BrevmottakerForm.tsx
@@ -79,41 +79,23 @@ export function BrevmottakerForm({
                         Ny brevmottaker
                     </Heading>
                     <MottakerFelt
-                        feltnavn={BrevmottakerFeltnavn.MOTTAKERROLLE}
                         personopplysninger={personopplysninger}
                         brevmottakere={brevmottakere}
                         erLesevisning={erLesevisning}
                     />
                     <LandFelt
-                        feltnavn={BrevmottakerFeltnavn.LANDKODE}
                         personopplysninger={personopplysninger}
                         erLesevisning={erLesevisning}
                     />
                     {erLandValgt && (
                         <>
-                            <NavnFelt
-                                feltnavn={BrevmottakerFeltnavn.NAVN}
-                                personopplysninger={personopplysninger}
-                                erLesevisning={erLesevisning}
-                            />
-                            <Adresselinje1Felt
-                                feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
-                                erLesevisning={erLesevisning}
-                            />
-                            <Adresselinje2Felt
-                                feltnavn={BrevmottakerFeltnavn.ADRESSELINJE2}
-                                erLesevisning={erLesevisning}
-                            />
+                            <NavnFelt erLesevisning={erLesevisning} />
+                            <Adresselinje1Felt erLesevisning={erLesevisning} />
+                            <Adresselinje2Felt erLesevisning={erLesevisning} />
                             {!erUtenlandskAdresseValgt && (
                                 <>
-                                    <PostnummerFelt
-                                        feltnavn={BrevmottakerFeltnavn.POSTNUMMER}
-                                        erLesevisning={erLesevisning}
-                                    />
-                                    <PoststedFelt
-                                        feltnavn={BrevmottakerFeltnavn.POSTSTED}
-                                        erLesevisning={erLesevisning}
-                                    />
+                                    <PostnummerFelt erLesevisning={erLesevisning} />
+                                    <PoststedFelt erLesevisning={erLesevisning} />
                                 </>
                             )}
                         </>

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/BrevmottakerForm.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/BrevmottakerForm.tsx
@@ -9,11 +9,12 @@ import { PoststedFelt } from './felt/PoststedFelt';
 import { Alert, Button, Heading, HStack, VStack } from '@navikt/ds-react';
 import {
     BlankEøsLandkode,
-    erUtanlandskEøsLandkode,
+    erEøsLandkode,
+    erUtenlandskEøsLandkode,
     EøsLandkode,
 } from '../../../../../../Felles/Landvelger/landkode';
 import { IPersonopplysninger } from '../../../../../../App/typer/personopplysninger';
-import { MottakerRolle, BlankMottakerRolle } from '../../../mottakerRolle';
+import { BlankMottakerRolle, MottakerRolle } from '../../../mottakerRolle';
 import { BrevmottakerPersonUtenIdent } from '../../../brevmottaker';
 import { lagNyBrevmottakerPersonUtenIdent, NyBrevmottaker } from '../../../nyBrevmottaker';
 import { Adresselinje2Felt } from './felt/Adresselinje2Felt';
@@ -68,6 +69,8 @@ export function BrevmottakerForm({
     const form = useForm<BrevmottakerFormValues>({ defaultValues });
     const { formState, handleSubmit, watch } = form;
 
+    const landkode = watch(BrevmottakerFeltnavn.LANDKODE);
+
     async function onSubmit(brevmottakerFormValues: BrevmottakerFormValues) {
         setVisSubmitError(false);
         const erSuksess = await opprettBrevmottaker(
@@ -79,10 +82,6 @@ export function BrevmottakerForm({
             setVisSubmitError(true);
         }
     }
-
-    const landkode = watch(BrevmottakerFeltnavn.LANDKODE);
-    const erLandValgt = landkode !== '';
-    const erUtenlandskEøsLandkode = erUtanlandskEøsLandkode(landkode);
 
     return (
         <FormProvider {...form}>
@@ -100,12 +99,12 @@ export function BrevmottakerForm({
                         personopplysninger={personopplysninger}
                         erLesevisning={erLesevisning}
                     />
-                    {erLandValgt && (
+                    {erEøsLandkode(landkode) && (
                         <>
                             <NavnFelt erLesevisning={erLesevisning} />
                             <Adresselinje1Felt erLesevisning={erLesevisning} />
                             <Adresselinje2Felt erLesevisning={erLesevisning} />
-                            {!erUtenlandskEøsLandkode && (
+                            {!erUtenlandskEøsLandkode(landkode) && (
                                 <>
                                     <PostnummerFelt erLesevisning={erLesevisning} />
                                     <PoststedFelt erLesevisning={erLesevisning} />

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/BrevmottakerForm.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/BrevmottakerForm.tsx
@@ -3,7 +3,7 @@ import { DefaultValues, FormProvider, useForm } from 'react-hook-form';
 import { LandFelt } from './felt/LandFelt';
 import { MottakerFelt } from './felt/MottakerFelt';
 import { NavnFelt } from './felt/NavnFelt';
-import { AdresselinjeFelt } from './felt/AdresselinjeFelt';
+import { Adresselinje1Felt } from './felt/Adresselinje1Felt';
 import { PostnummerFelt } from './felt/PostnummerFelt';
 import { PoststedFelt } from './felt/PoststedFelt';
 import { Alert, Button, Heading, HStack, VStack } from '@navikt/ds-react';
@@ -13,6 +13,7 @@ import { BrevmottakerFeltnavn } from './felt/felttyper';
 import { MottakerRolle } from '../../../mottakerRolle';
 import { BrevmottakerPersonUtenIdent } from '../../../brevmottaker';
 import { lagNyBrevmottakerPersonUtenIdent, NyBrevmottaker } from '../../../nyBrevmottaker';
+import { Adresselinje2Felt } from './felt/Adresselinje2Felt';
 
 export type BrevmottakerFormValues = {
     [BrevmottakerFeltnavn.MOTTAKERROLLE]: MottakerRolle | '';
@@ -98,25 +99,15 @@ export function BrevmottakerForm({
                                 personopplysninger={personopplysninger}
                                 erLesevisning={erLesevisning}
                             />
-                            <AdresselinjeFelt
+                            <Adresselinje1Felt
                                 feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
                                 visningsnavn={'Adresselinje 1'}
                                 erLesevisning={erLesevisning}
-                                valgfri={false}
-                                beskrivelse={
-                                    erUtenlandskAdresseValgt && (
-                                        <Alert size={'small'} inline={true} variant={'info'}>
-                                            Ved utenlandsk adresse skal postnummer og poststed
-                                            skrives direkte i adressefeltet.
-                                        </Alert>
-                                    )
-                                }
                             />
-                            <AdresselinjeFelt
+                            <Adresselinje2Felt
                                 feltnavn={BrevmottakerFeltnavn.ADRESSELINJE2}
                                 visningsnavn={'Adresselinje 2 (valgfri)'}
                                 erLesevisning={erLesevisning}
-                                valgfri={true}
                             />
                             {!erUtenlandskAdresseValgt && (
                                 <>

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/BrevmottakerForm.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/BrevmottakerForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { DefaultValues, FormProvider, useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import { LandFelt } from './felt/LandFelt';
 import { MottakerFelt } from './felt/MottakerFelt';
 import { NavnFelt } from './felt/NavnFelt';
@@ -29,7 +29,7 @@ export enum BrevmottakerFeltnavn {
     POSTSTED = 'poststed',
 }
 
-export type BrevmottakerFormValues = {
+export interface BrevmottakerFormValues {
     [BrevmottakerFeltnavn.MOTTAKERROLLE]: MottakerRolle | BlankMottakerRolle;
     [BrevmottakerFeltnavn.LANDKODE]: EøsLandkode | BlankEøsLandkode;
     [BrevmottakerFeltnavn.NAVN]: string;
@@ -37,26 +37,16 @@ export type BrevmottakerFormValues = {
     [BrevmottakerFeltnavn.ADRESSELINJE2]: string;
     [BrevmottakerFeltnavn.POSTNUMMER]: string;
     [BrevmottakerFeltnavn.POSTSTED]: string;
-};
+}
 
-const defaultValues: DefaultValues<BrevmottakerFormValues> = {
-    [BrevmottakerFeltnavn.MOTTAKERROLLE]: '',
-    [BrevmottakerFeltnavn.LANDKODE]: EøsLandkode.NO,
-    [BrevmottakerFeltnavn.NAVN]: '',
-    [BrevmottakerFeltnavn.ADRESSELINJE1]: '',
-    [BrevmottakerFeltnavn.ADRESSELINJE2]: '',
-    [BrevmottakerFeltnavn.POSTNUMMER]: '',
-    [BrevmottakerFeltnavn.POSTSTED]: '',
-};
-
-type Props = {
+interface Props {
     behandlingId: string;
     personopplysninger: IPersonopplysninger;
     brevmottakere: BrevmottakerPersonUtenIdent[];
     erLesevisning: boolean;
     lukkForm: () => void;
     opprettBrevmottaker: (nyBrevmottaker: NyBrevmottaker) => Promise<boolean>;
-};
+}
 
 export function BrevmottakerForm({
     personopplysninger,
@@ -66,8 +56,24 @@ export function BrevmottakerForm({
     opprettBrevmottaker,
 }: Props) {
     const [visSubmitError, setVisSubmitError] = useState<boolean>(false);
-    const form = useForm<BrevmottakerFormValues>({ defaultValues });
-    const { formState, handleSubmit, watch } = form;
+
+    const form = useForm<BrevmottakerFormValues>({
+        defaultValues: {
+            [BrevmottakerFeltnavn.MOTTAKERROLLE]: '',
+            [BrevmottakerFeltnavn.LANDKODE]: EøsLandkode.NO,
+            [BrevmottakerFeltnavn.NAVN]: '',
+            [BrevmottakerFeltnavn.ADRESSELINJE1]: '',
+            [BrevmottakerFeltnavn.ADRESSELINJE2]: '',
+            [BrevmottakerFeltnavn.POSTNUMMER]: '',
+            [BrevmottakerFeltnavn.POSTSTED]: '',
+        },
+    });
+
+    const {
+        handleSubmit,
+        formState: { isSubmitting },
+        watch,
+    } = form;
 
     const landkode = watch(BrevmottakerFeltnavn.LANDKODE);
 
@@ -123,15 +129,11 @@ export function BrevmottakerForm({
                     )}
                     <HStack gap={'4'}>
                         {!erLesevisning && (
-                            <Button
-                                variant={'primary'}
-                                type={'submit'}
-                                loading={formState.isSubmitting}
-                            >
+                            <Button variant={'primary'} type={'submit'} loading={isSubmitting}>
                                 Legg til brevmottaker
                             </Button>
                         )}
-                        {!erLesevisning && brevmottakere.length > 0 && !formState.isSubmitting && (
+                        {!erLesevisning && brevmottakere.length > 0 && !isSubmitting && (
                             <Button variant={'tertiary'} onClick={lukkForm}>
                                 Avbryt legg til brevmottaker
                             </Button>

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/BrevmottakerForm.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/BrevmottakerForm.tsx
@@ -80,14 +80,12 @@ export function BrevmottakerForm({
                     </Heading>
                     <MottakerFelt
                         feltnavn={BrevmottakerFeltnavn.MOTTAKERROLLE}
-                        visningsnavn={'Mottaker'}
                         personopplysninger={personopplysninger}
                         brevmottakere={brevmottakere}
                         erLesevisning={erLesevisning}
                     />
                     <LandFelt
                         feltnavn={BrevmottakerFeltnavn.LANDKODE}
-                        visningsnavn={'Land'}
                         personopplysninger={personopplysninger}
                         erLesevisning={erLesevisning}
                     />
@@ -95,30 +93,25 @@ export function BrevmottakerForm({
                         <>
                             <NavnFelt
                                 feltnavn={BrevmottakerFeltnavn.NAVN}
-                                visningsnavn={'Navn'}
                                 personopplysninger={personopplysninger}
                                 erLesevisning={erLesevisning}
                             />
                             <Adresselinje1Felt
                                 feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
-                                visningsnavn={'Adresselinje 1'}
                                 erLesevisning={erLesevisning}
                             />
                             <Adresselinje2Felt
                                 feltnavn={BrevmottakerFeltnavn.ADRESSELINJE2}
-                                visningsnavn={'Adresselinje 2 (valgfri)'}
                                 erLesevisning={erLesevisning}
                             />
                             {!erUtenlandskAdresseValgt && (
                                 <>
                                     <PostnummerFelt
                                         feltnavn={BrevmottakerFeltnavn.POSTNUMMER}
-                                        visningsnavn={'Postnummer'}
                                         erLesevisning={erLesevisning}
                                     />
                                     <PoststedFelt
                                         feltnavn={BrevmottakerFeltnavn.POSTSTED}
-                                        visningsnavn={'Poststed'}
                                         erLesevisning={erLesevisning}
                                     />
                                 </>

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje1Felt.test.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje1Felt.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { describe, expect, test } from 'vitest';
-import { AdresselinjeFelt } from './AdresselinjeFelt';
+import { Adresselinje1Felt } from './Adresselinje1Felt';
 import { BrevmottakerFeltnavn } from './felttyper';
 import { DefaultValues, FormProvider, useForm } from 'react-hook-form';
 import { BrevmottakerFormValues } from '../BrevmottakerForm';
@@ -39,7 +39,7 @@ const visningsnavn = 'Adresselinje 1';
 describe('AdresselinjeFelt', () => {
     test('skal kunne skrive hvis komponenten ikke er i lesevisning', async () => {
         const { screen, user } = render(
-            <AdresselinjeFelt
+            <Adresselinje1Felt
                 feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
                 visningsnavn={visningsnavn}
                 erLesevisning={false}
@@ -58,7 +58,7 @@ describe('AdresselinjeFelt', () => {
 
     test('skal ikke kunne skrive hvis komponenten er i lesevisning', async () => {
         const { screen, user } = render(
-            <AdresselinjeFelt
+            <Adresselinje1Felt
                 feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
                 visningsnavn={visningsnavn}
                 erLesevisning={true}
@@ -77,7 +77,7 @@ describe('AdresselinjeFelt', () => {
 
     test('skal fokusere som forventet på tekstfeltet når brukeren klikker på tekstfeltet for å så tabbe ut', async () => {
         const { screen, user } = render(
-            <AdresselinjeFelt
+            <Adresselinje1Felt
                 feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
                 visningsnavn={visningsnavn}
             />,
@@ -92,12 +92,11 @@ describe('AdresselinjeFelt', () => {
         expect(textbox).not.toHaveFocus();
     });
 
-    test('skal vise "påkrevd" feilmelding hvis feltet ikke er valgfri og feltet er tomt', async () => {
+    test('skal vise "påkrevd" feilmelding hvis feltet er tomt', async () => {
         const { screen, user } = render(
-            <AdresselinjeFelt
+            <Adresselinje1Felt
                 feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
                 visningsnavn={visningsnavn}
-                valgfri={false}
             />,
             { wrapper: FormWrapper }
         );
@@ -112,29 +111,9 @@ describe('AdresselinjeFelt', () => {
         expect(feilmelding).toBeInTheDocument();
     });
 
-    test('skal ikke vise "påkrevd" feilmelding hvis feltet er valgfri og feltet er tomt', async () => {
-        const { screen, user } = render(
-            <AdresselinjeFelt
-                feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
-                visningsnavn={visningsnavn}
-                valgfri={true}
-            />,
-            { wrapper: FormWrapper }
-        );
-
-        const textbox = screen.getByRole('textbox', { name: visningsnavn });
-        await user.click(textbox);
-        await user.keyboard('Abc');
-        await user.clear(textbox);
-        await user.tab();
-
-        const feilmelding = screen.queryByText(`${visningsnavn} er påkrevd.`);
-        expect(feilmelding).not.toBeInTheDocument();
-    });
-
     test('skal vise maks lengde feilmelding hvis feltet overstiger 80 tegn', async () => {
         const { screen, user } = render(
-            <AdresselinjeFelt
+            <Adresselinje1Felt
                 feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
                 visningsnavn={visningsnavn}
             />,
@@ -154,7 +133,7 @@ describe('AdresselinjeFelt', () => {
 
     test('skal ikke vise maks lengde feilmelding hvis feltet inneholder 80 tegn', async () => {
         const { screen, user } = render(
-            <AdresselinjeFelt
+            <Adresselinje1Felt
                 feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
                 visningsnavn={visningsnavn}
             />,
@@ -176,7 +155,7 @@ describe('AdresselinjeFelt', () => {
 
     test('skal vise komponent med utfylt verdi fra form state', async () => {
         const { screen } = render(
-            <AdresselinjeFelt
+            <Adresselinje1Felt
                 feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
                 visningsnavn={visningsnavn}
             />,
@@ -199,7 +178,7 @@ describe('AdresselinjeFelt', () => {
 
     test('skal ikke kunne skrive hvis formet blir submitted', async () => {
         const { screen, user } = render(
-            <AdresselinjeFelt
+            <Adresselinje1Felt
                 feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
                 visningsnavn={visningsnavn}
             />,

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje1Felt.test.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje1Felt.test.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 
 import { describe, expect, test } from 'vitest';
 import { Adresselinje1Felt } from './Adresselinje1Felt';
-import { BrevmottakerFeltnavn } from './felttyper';
 import { DefaultValues, FormProvider, useForm } from 'react-hook-form';
-import { BrevmottakerFormValues } from '../BrevmottakerForm';
+import { BrevmottakerFeltnavn, BrevmottakerFormValues } from '../BrevmottakerForm';
 import { render } from '../../../../../../../lib/testrender';
 import { Button } from '@navikt/ds-react';
 

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje1Felt.test.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje1Felt.test.tsx
@@ -38,13 +38,9 @@ const visningsnavn = 'Adresselinje 1';
 
 describe('AdresselinjeFelt', () => {
     test('skal kunne skrive hvis komponenten ikke er i lesevisning', async () => {
-        const { screen, user } = render(
-            <Adresselinje1Felt
-                feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
-                erLesevisning={false}
-            />,
-            { wrapper: FormWrapper }
-        );
+        const { screen, user } = render(<Adresselinje1Felt erLesevisning={false} />, {
+            wrapper: FormWrapper,
+        });
 
         const textbox = screen.getByRole('textbox', { name: visningsnavn });
         await user.click(textbox);
@@ -56,13 +52,9 @@ describe('AdresselinjeFelt', () => {
     });
 
     test('skal ikke kunne skrive hvis komponenten er i lesevisning', async () => {
-        const { screen, user } = render(
-            <Adresselinje1Felt
-                feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
-                erLesevisning={true}
-            />,
-            { wrapper: FormWrapper }
-        );
+        const { screen, user } = render(<Adresselinje1Felt erLesevisning={true} />, {
+            wrapper: FormWrapper,
+        });
 
         const textbox = screen.getByRole('textbox', { name: visningsnavn });
         await user.click(textbox);
@@ -74,10 +66,7 @@ describe('AdresselinjeFelt', () => {
     });
 
     test('skal fokusere som forventet på tekstfeltet når brukeren klikker på tekstfeltet for å så tabbe ut', async () => {
-        const { screen, user } = render(
-            <Adresselinje1Felt feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1} />,
-            { wrapper: FormWrapper }
-        );
+        const { screen, user } = render(<Adresselinje1Felt />, { wrapper: FormWrapper });
 
         const textbox = screen.getByRole('textbox', { name: visningsnavn });
         expect(textbox).not.toHaveFocus();
@@ -88,10 +77,7 @@ describe('AdresselinjeFelt', () => {
     });
 
     test('skal vise "påkrevd" feilmelding hvis feltet er tomt', async () => {
-        const { screen, user } = render(
-            <Adresselinje1Felt feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1} />,
-            { wrapper: FormWrapper }
-        );
+        const { screen, user } = render(<Adresselinje1Felt />, { wrapper: FormWrapper });
 
         const textbox = screen.getByRole('textbox', { name: visningsnavn });
         await user.click(textbox);
@@ -104,10 +90,7 @@ describe('AdresselinjeFelt', () => {
     });
 
     test('skal vise maks lengde feilmelding hvis feltet overstiger 80 tegn', async () => {
-        const { screen, user } = render(
-            <Adresselinje1Felt feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1} />,
-            { wrapper: FormWrapper }
-        );
+        const { screen, user } = render(<Adresselinje1Felt />, { wrapper: FormWrapper });
 
         const textbox = screen.getByRole('textbox', { name: visningsnavn });
         await user.click(textbox);
@@ -121,10 +104,7 @@ describe('AdresselinjeFelt', () => {
     });
 
     test('skal ikke vise maks lengde feilmelding hvis feltet inneholder 80 tegn', async () => {
-        const { screen, user } = render(
-            <Adresselinje1Felt feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1} />,
-            { wrapper: FormWrapper }
-        );
+        const { screen, user } = render(<Adresselinje1Felt />, { wrapper: FormWrapper });
 
         const textbox = screen.getByRole('textbox', { name: visningsnavn });
         await user.click(textbox);
@@ -140,32 +120,26 @@ describe('AdresselinjeFelt', () => {
     });
 
     test('skal vise komponent med utfylt verdi fra form state', async () => {
-        const { screen } = render(
-            <Adresselinje1Felt feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1} />,
-            {
-                wrapper: (props) => (
-                    <FormWrapper
-                        {...props}
-                        defaultValues={{
-                            ...DEFAULT_VALUES,
-                            [BrevmottakerFeltnavn.ADRESSELINJE1]: 'Osloveien 1337',
-                        }}
-                    />
-                ),
-            }
-        );
+        const { screen } = render(<Adresselinje1Felt />, {
+            wrapper: (props) => (
+                <FormWrapper
+                    {...props}
+                    defaultValues={{
+                        ...DEFAULT_VALUES,
+                        [BrevmottakerFeltnavn.ADRESSELINJE1]: 'Osloveien 1337',
+                    }}
+                />
+            ),
+        });
 
         const textbox = screen.getByRole('textbox', { name: visningsnavn });
         expect(textbox).toHaveValue('Osloveien 1337');
     });
 
     test('skal ikke kunne skrive hvis formet blir submitted', async () => {
-        const { screen, user } = render(
-            <Adresselinje1Felt feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1} />,
-            {
-                wrapper: (props) => <FormWrapper {...props} onSubmitDelay={3_000} />,
-            }
-        );
+        const { screen, user } = render(<Adresselinje1Felt />, {
+            wrapper: (props) => <FormWrapper {...props} onSubmitDelay={3_000} />,
+        });
 
         const textbox = screen.getByRole('textbox', { name: visningsnavn });
         await user.click(textbox);

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje1Felt.test.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje1Felt.test.tsx
@@ -33,7 +33,7 @@ function FormWrapper({
     );
 }
 
-const visningsnavn = 'Adresselinje 1';
+const label = 'Adresselinje 1';
 
 describe('AdresselinjeFelt', () => {
     test('skal kunne skrive hvis komponenten ikke er i lesevisning', async () => {
@@ -41,7 +41,7 @@ describe('AdresselinjeFelt', () => {
             wrapper: FormWrapper,
         });
 
-        const textbox = screen.getByRole('textbox', { name: visningsnavn });
+        const textbox = screen.getByRole('textbox', { name: label });
         await user.click(textbox);
         await user.keyboard('Dette er en prøve');
 
@@ -55,7 +55,7 @@ describe('AdresselinjeFelt', () => {
             wrapper: FormWrapper,
         });
 
-        const textbox = screen.getByRole('textbox', { name: visningsnavn });
+        const textbox = screen.getByRole('textbox', { name: label });
         await user.click(textbox);
         await user.keyboard('Dette er en prøve');
 
@@ -67,7 +67,7 @@ describe('AdresselinjeFelt', () => {
     test('skal fokusere som forventet på tekstfeltet når brukeren klikker på tekstfeltet for å så tabbe ut', async () => {
         const { screen, user } = render(<Adresselinje1Felt />, { wrapper: FormWrapper });
 
-        const textbox = screen.getByRole('textbox', { name: visningsnavn });
+        const textbox = screen.getByRole('textbox', { name: label });
         expect(textbox).not.toHaveFocus();
         await user.click(textbox);
         expect(textbox).toHaveFocus();
@@ -78,43 +78,41 @@ describe('AdresselinjeFelt', () => {
     test('skal vise "påkrevd" feilmelding hvis feltet er tomt', async () => {
         const { screen, user } = render(<Adresselinje1Felt />, { wrapper: FormWrapper });
 
-        const textbox = screen.getByRole('textbox', { name: visningsnavn });
+        const textbox = screen.getByRole('textbox', { name: label });
         await user.click(textbox);
         await user.keyboard('Abc');
         await user.clear(textbox);
         await user.tab();
 
-        const feilmelding = screen.getByText(`${visningsnavn} er påkrevd.`);
+        const feilmelding = screen.getByText(`${label} er påkrevd.`);
         expect(feilmelding).toBeInTheDocument();
     });
 
     test('skal vise maks lengde feilmelding hvis feltet overstiger 80 tegn', async () => {
         const { screen, user } = render(<Adresselinje1Felt />, { wrapper: FormWrapper });
 
-        const textbox = screen.getByRole('textbox', { name: visningsnavn });
+        const textbox = screen.getByRole('textbox', { name: label });
         await user.click(textbox);
         await user.keyboard(
             'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligulade'
         );
         await user.tab();
 
-        const feilmelding = screen.getByText(`${visningsnavn} kan ikke inneholde mer enn 80 tegn.`);
+        const feilmelding = screen.getByText(`${label} kan ikke inneholde mer enn 80 tegn.`);
         expect(feilmelding).toBeInTheDocument();
     });
 
     test('skal ikke vise maks lengde feilmelding hvis feltet inneholder 80 tegn', async () => {
         const { screen, user } = render(<Adresselinje1Felt />, { wrapper: FormWrapper });
 
-        const textbox = screen.getByRole('textbox', { name: visningsnavn });
+        const textbox = screen.getByRole('textbox', { name: label });
         await user.click(textbox);
         await user.keyboard(
             'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligulaa'
         );
         await user.tab();
 
-        const feilmelding = screen.queryByText(
-            `${visningsnavn} kan ikke inneholde mer enn 80 tegn.`
-        );
+        const feilmelding = screen.queryByText(`${label} kan ikke inneholde mer enn 80 tegn.`);
         expect(feilmelding).not.toBeInTheDocument();
     });
 
@@ -131,7 +129,7 @@ describe('AdresselinjeFelt', () => {
             ),
         });
 
-        const textbox = screen.getByRole('textbox', { name: visningsnavn });
+        const textbox = screen.getByRole('textbox', { name: label });
         expect(textbox).toHaveValue('Osloveien 1337');
     });
 
@@ -140,7 +138,7 @@ describe('AdresselinjeFelt', () => {
             wrapper: (props) => <FormWrapper {...props} onSubmitDelay={3_000} />,
         });
 
-        const textbox = screen.getByRole('textbox', { name: visningsnavn });
+        const textbox = screen.getByRole('textbox', { name: label });
         await user.click(textbox);
         await user.keyboard('abc');
 

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje1Felt.test.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje1Felt.test.tsx
@@ -41,7 +41,6 @@ describe('AdresselinjeFelt', () => {
         const { screen, user } = render(
             <Adresselinje1Felt
                 feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
-                visningsnavn={visningsnavn}
                 erLesevisning={false}
             />,
             { wrapper: FormWrapper }
@@ -60,7 +59,6 @@ describe('AdresselinjeFelt', () => {
         const { screen, user } = render(
             <Adresselinje1Felt
                 feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
-                visningsnavn={visningsnavn}
                 erLesevisning={true}
             />,
             { wrapper: FormWrapper }
@@ -77,10 +75,7 @@ describe('AdresselinjeFelt', () => {
 
     test('skal fokusere som forventet på tekstfeltet når brukeren klikker på tekstfeltet for å så tabbe ut', async () => {
         const { screen, user } = render(
-            <Adresselinje1Felt
-                feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
-                visningsnavn={visningsnavn}
-            />,
+            <Adresselinje1Felt feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1} />,
             { wrapper: FormWrapper }
         );
 
@@ -94,10 +89,7 @@ describe('AdresselinjeFelt', () => {
 
     test('skal vise "påkrevd" feilmelding hvis feltet er tomt', async () => {
         const { screen, user } = render(
-            <Adresselinje1Felt
-                feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
-                visningsnavn={visningsnavn}
-            />,
+            <Adresselinje1Felt feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1} />,
             { wrapper: FormWrapper }
         );
 
@@ -113,10 +105,7 @@ describe('AdresselinjeFelt', () => {
 
     test('skal vise maks lengde feilmelding hvis feltet overstiger 80 tegn', async () => {
         const { screen, user } = render(
-            <Adresselinje1Felt
-                feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
-                visningsnavn={visningsnavn}
-            />,
+            <Adresselinje1Felt feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1} />,
             { wrapper: FormWrapper }
         );
 
@@ -133,10 +122,7 @@ describe('AdresselinjeFelt', () => {
 
     test('skal ikke vise maks lengde feilmelding hvis feltet inneholder 80 tegn', async () => {
         const { screen, user } = render(
-            <Adresselinje1Felt
-                feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
-                visningsnavn={visningsnavn}
-            />,
+            <Adresselinje1Felt feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1} />,
             { wrapper: FormWrapper }
         );
 
@@ -155,10 +141,7 @@ describe('AdresselinjeFelt', () => {
 
     test('skal vise komponent med utfylt verdi fra form state', async () => {
         const { screen } = render(
-            <Adresselinje1Felt
-                feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
-                visningsnavn={visningsnavn}
-            />,
+            <Adresselinje1Felt feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1} />,
             {
                 wrapper: (props) => (
                     <FormWrapper
@@ -178,10 +161,7 @@ describe('AdresselinjeFelt', () => {
 
     test('skal ikke kunne skrive hvis formet blir submitted', async () => {
         const { screen, user } = render(
-            <Adresselinje1Felt
-                feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
-                visningsnavn={visningsnavn}
-            />,
+            <Adresselinje1Felt feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1} />,
             {
                 wrapper: (props) => <FormWrapper {...props} onSubmitDelay={3_000} />,
             }

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje1Felt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje1Felt.tsx
@@ -1,19 +1,21 @@
 import { useController, useFormContext } from 'react-hook-form';
 import React from 'react';
 import { Alert, TextField } from '@navikt/ds-react';
-import { BrevmottakerFeltnavn, BrevmottakerFeltProps } from './felttyper';
+import { BrevmottakerFeltnavn } from './felttyper';
 import { EøsLandkode } from '../../../../../../../Felles/Landvelger/landkode';
 import { BrevmottakerFormValues } from '../BrevmottakerForm';
 
-type Props = BrevmottakerFeltProps & {};
+interface Props {
+    erLesevisning?: boolean;
+}
 
 const visningsnavn = 'Adresselinje 1';
 
-export function Adresselinje1Felt({ feltnavn, erLesevisning = false }: Props) {
+export function Adresselinje1Felt({ erLesevisning = false }: Props) {
     const { control, watch } = useFormContext<BrevmottakerFormValues>();
 
     const { field, fieldState, formState } = useController({
-        name: feltnavn,
+        name: BrevmottakerFeltnavn.ADRESSELINJE1,
         control,
         rules: {
             required: `${visningsnavn} er påkrevd.`,

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje1Felt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje1Felt.tsx
@@ -1,7 +1,7 @@
 import { useController, useFormContext } from 'react-hook-form';
 import React from 'react';
 import { Alert, TextField } from '@navikt/ds-react';
-import { erUtanlandskEøsLandkode } from '../../../../../../../Felles/Landvelger/landkode';
+import { erUtenlandskEøsLandkode } from '../../../../../../../Felles/Landvelger/landkode';
 import { BrevmottakerFeltnavn, BrevmottakerFormValues } from '../BrevmottakerForm';
 
 interface Props {
@@ -25,7 +25,7 @@ export function Adresselinje1Felt({ erLesevisning = false }: Props) {
         },
     });
 
-    const erUtenlandskLandkode = erUtanlandskEøsLandkode(watch(BrevmottakerFeltnavn.LANDKODE));
+    const landkode = watch(BrevmottakerFeltnavn.LANDKODE);
 
     return (
         <TextField
@@ -35,7 +35,7 @@ export function Adresselinje1Felt({ erLesevisning = false }: Props) {
             onChange={field.onChange}
             error={fieldState.error?.message}
             description={
-                erUtenlandskLandkode && (
+                erUtenlandskEøsLandkode(landkode) && (
                     <Alert size={'small'} inline={true} variant={'info'}>
                         Ved utenlandsk adresse skal postnummer og poststed skrives direkte i
                         adressefeltet.

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje1Felt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje1Felt.tsx
@@ -8,7 +8,7 @@ interface Props {
     erLesevisning?: boolean;
 }
 
-const visningsnavn = 'Adresselinje 1';
+const label = 'Adresselinje 1';
 
 export function Adresselinje1Felt({ erLesevisning = false }: Props) {
     const { control, watch } = useFormContext<BrevmottakerFormValues>();
@@ -17,10 +17,10 @@ export function Adresselinje1Felt({ erLesevisning = false }: Props) {
         name: BrevmottakerFeltnavn.ADRESSELINJE1,
         control,
         rules: {
-            required: `${visningsnavn} er påkrevd.`,
+            required: `${label} er påkrevd.`,
             maxLength: {
                 value: 80,
-                message: `${visningsnavn} kan ikke inneholde mer enn 80 tegn.`,
+                message: `${label} kan ikke inneholde mer enn 80 tegn.`,
             },
         },
     });
@@ -29,7 +29,7 @@ export function Adresselinje1Felt({ erLesevisning = false }: Props) {
 
     return (
         <TextField
-            label={visningsnavn}
+            label={label}
             value={field.value}
             onBlur={field.onBlur}
             onChange={field.onChange}

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje1Felt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje1Felt.tsx
@@ -29,15 +29,13 @@ export function Adresselinje1Felt({ erLesevisning = false }: Props) {
     const erLandValgt = landkode !== '';
     const erUtenlandskAdresseValgt = erLandValgt && landkode !== EøsLandkode.NO;
 
-    const visFeilmelding = fieldState.isTouched || formState.isSubmitted;
-
     return (
         <TextField
             label={visningsnavn}
             value={field.value}
             onBlur={field.onBlur}
             onChange={field.onChange}
-            error={visFeilmelding && fieldState.error?.message}
+            error={fieldState.error?.message}
             description={
                 erUtenlandskAdresseValgt && (
                     <Alert size={'small'} inline={true} variant={'info'}>

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje1Felt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje1Felt.tsx
@@ -1,7 +1,7 @@
 import { useController, useFormContext } from 'react-hook-form';
 import React from 'react';
 import { Alert, TextField } from '@navikt/ds-react';
-import { EøsLandkode } from '../../../../../../../Felles/Landvelger/landkode';
+import { erUtanlandskEøsLandkode } from '../../../../../../../Felles/Landvelger/landkode';
 import { BrevmottakerFeltnavn, BrevmottakerFormValues } from '../BrevmottakerForm';
 
 interface Props {
@@ -25,9 +25,7 @@ export function Adresselinje1Felt({ erLesevisning = false }: Props) {
         },
     });
 
-    const landkode = watch(BrevmottakerFeltnavn.LANDKODE);
-    const erLandValgt = landkode !== '';
-    const erUtenlandskAdresseValgt = erLandValgt && landkode !== EøsLandkode.NO;
+    const erUtenlandskLandkode = erUtanlandskEøsLandkode(watch(BrevmottakerFeltnavn.LANDKODE));
 
     return (
         <TextField
@@ -37,7 +35,7 @@ export function Adresselinje1Felt({ erLesevisning = false }: Props) {
             onChange={field.onChange}
             error={fieldState.error?.message}
             description={
-                erUtenlandskAdresseValgt && (
+                erUtenlandskLandkode && (
                     <Alert size={'small'} inline={true} variant={'info'}>
                         Ved utenlandsk adresse skal postnummer og poststed skrives direkte i
                         adressefeltet.

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje1Felt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje1Felt.tsx
@@ -1,0 +1,48 @@
+import { useController, useFormContext } from 'react-hook-form';
+import React from 'react';
+import { Alert, TextField } from '@navikt/ds-react';
+import { BrevmottakerFeltnavn, BrevmottakerFeltProps } from './felttyper';
+import { EøsLandkode } from '../../../../../../../Felles/Landvelger/landkode';
+
+type Props = BrevmottakerFeltProps & {};
+
+export function Adresselinje1Felt({ feltnavn, visningsnavn, erLesevisning = false }: Props) {
+    const { control, watch } = useFormContext();
+
+    const { field, fieldState, formState } = useController({
+        name: feltnavn,
+        control,
+        rules: {
+            required: `${visningsnavn} er påkrevd.`,
+            maxLength: {
+                value: 80,
+                message: `${visningsnavn} kan ikke inneholde mer enn 80 tegn.`,
+            },
+        },
+    });
+
+    const landkode = watch(BrevmottakerFeltnavn.LANDKODE);
+    const erLandValgt = landkode !== '';
+    const erUtenlandskAdresseValgt = erLandValgt && landkode !== EøsLandkode.NO;
+
+    const visFeilmelding = fieldState.isTouched || formState.isSubmitted;
+
+    return (
+        <TextField
+            label={visningsnavn}
+            value={field.value}
+            onBlur={field.onBlur}
+            onChange={field.onChange}
+            error={visFeilmelding && fieldState.error?.message}
+            description={
+                erUtenlandskAdresseValgt && (
+                    <Alert size={'small'} inline={true} variant={'info'}>
+                        Ved utenlandsk adresse skal postnummer og poststed skrives direkte i
+                        adressefeltet.
+                    </Alert>
+                )
+            }
+            readOnly={erLesevisning || formState.isSubmitting}
+        />
+    );
+}

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje1Felt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje1Felt.tsx
@@ -6,7 +6,9 @@ import { EøsLandkode } from '../../../../../../../Felles/Landvelger/landkode';
 
 type Props = BrevmottakerFeltProps & {};
 
-export function Adresselinje1Felt({ feltnavn, visningsnavn, erLesevisning = false }: Props) {
+const visningsnavn = 'Adresselinje 1';
+
+export function Adresselinje1Felt({ feltnavn, erLesevisning = false }: Props) {
     const { control, watch } = useFormContext();
 
     const { field, fieldState, formState } = useController({

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje1Felt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje1Felt.tsx
@@ -3,13 +3,14 @@ import React from 'react';
 import { Alert, TextField } from '@navikt/ds-react';
 import { BrevmottakerFeltnavn, BrevmottakerFeltProps } from './felttyper';
 import { EøsLandkode } from '../../../../../../../Felles/Landvelger/landkode';
+import { BrevmottakerFormValues } from '../BrevmottakerForm';
 
 type Props = BrevmottakerFeltProps & {};
 
 const visningsnavn = 'Adresselinje 1';
 
 export function Adresselinje1Felt({ feltnavn, erLesevisning = false }: Props) {
-    const { control, watch } = useFormContext();
+    const { control, watch } = useFormContext<BrevmottakerFormValues>();
 
     const { field, fieldState, formState } = useController({
         name: feltnavn,

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje1Felt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje1Felt.tsx
@@ -1,9 +1,8 @@
 import { useController, useFormContext } from 'react-hook-form';
 import React from 'react';
 import { Alert, TextField } from '@navikt/ds-react';
-import { BrevmottakerFeltnavn } from './felttyper';
 import { EøsLandkode } from '../../../../../../../Felles/Landvelger/landkode';
-import { BrevmottakerFormValues } from '../BrevmottakerForm';
+import { BrevmottakerFeltnavn, BrevmottakerFormValues } from '../BrevmottakerForm';
 
 interface Props {
     erLesevisning?: boolean;

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje2Felt.test.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje2Felt.test.tsx
@@ -34,14 +34,13 @@ function FormWrapper({
     );
 }
 
-const visningsnavn = 'Adresselinje 1';
+const visningsnavn = 'Adresselinje 2 (valgfri)';
 
 describe('AdresselinjeFelt', () => {
     test('skal kunne skrive hvis komponenten ikke er i lesevisning', async () => {
         const { screen, user } = render(
             <Adresselinje2Felt
                 feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
-                visningsnavn={visningsnavn}
                 erLesevisning={false}
             />,
             { wrapper: FormWrapper }
@@ -60,7 +59,6 @@ describe('AdresselinjeFelt', () => {
         const { screen, user } = render(
             <Adresselinje2Felt
                 feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
-                visningsnavn={visningsnavn}
                 erLesevisning={true}
             />,
             { wrapper: FormWrapper }
@@ -77,10 +75,7 @@ describe('AdresselinjeFelt', () => {
 
     test('skal fokusere som forventet på tekstfeltet når brukeren klikker på tekstfeltet for å så tabbe ut', async () => {
         const { screen, user } = render(
-            <Adresselinje2Felt
-                feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
-                visningsnavn={visningsnavn}
-            />,
+            <Adresselinje2Felt feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1} />,
             { wrapper: FormWrapper }
         );
 
@@ -94,10 +89,7 @@ describe('AdresselinjeFelt', () => {
 
     test('skal vise maks lengde feilmelding hvis feltet overstiger 80 tegn', async () => {
         const { screen, user } = render(
-            <Adresselinje2Felt
-                feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
-                visningsnavn={visningsnavn}
-            />,
+            <Adresselinje2Felt feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1} />,
             { wrapper: FormWrapper }
         );
 
@@ -114,10 +106,7 @@ describe('AdresselinjeFelt', () => {
 
     test('skal ikke vise maks lengde feilmelding hvis feltet inneholder 80 tegn', async () => {
         const { screen, user } = render(
-            <Adresselinje2Felt
-                feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
-                visningsnavn={visningsnavn}
-            />,
+            <Adresselinje2Felt feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1} />,
             { wrapper: FormWrapper }
         );
 
@@ -136,10 +125,7 @@ describe('AdresselinjeFelt', () => {
 
     test('skal vise komponent med utfylt verdi fra form state', async () => {
         const { screen } = render(
-            <Adresselinje2Felt
-                feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
-                visningsnavn={visningsnavn}
-            />,
+            <Adresselinje2Felt feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1} />,
             {
                 wrapper: (props) => (
                     <FormWrapper
@@ -159,10 +145,7 @@ describe('AdresselinjeFelt', () => {
 
     test('skal ikke kunne skrive hvis formet blir submitted', async () => {
         const { screen, user } = render(
-            <Adresselinje2Felt
-                feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
-                visningsnavn={visningsnavn}
-            />,
+            <Adresselinje2Felt feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1} />,
             {
                 wrapper: (props) => <FormWrapper {...props} onSubmitDelay={3_000} />,
             }

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje2Felt.test.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje2Felt.test.tsx
@@ -2,16 +2,15 @@ import React from 'react';
 
 import { describe, expect, test } from 'vitest';
 import { Adresselinje2Felt } from './Adresselinje2Felt';
-import { BrevmottakerFeltnavn } from './felttyper';
 import { DefaultValues, FormProvider, useForm } from 'react-hook-form';
-import { BrevmottakerFormValues } from '../BrevmottakerForm';
+import { BrevmottakerFeltnavn, BrevmottakerFormValues } from '../BrevmottakerForm';
 import { render } from '../../../../../../../lib/testrender';
 import { Button } from '@navikt/ds-react';
 
 const onSubmit = (delay: number) => new Promise((resolve) => setTimeout(resolve, delay));
 
 const DEFAULT_VALUES: DefaultValues<BrevmottakerFormValues> = {
-    [BrevmottakerFeltnavn.ADRESSELINJE1]: '',
+    [BrevmottakerFeltnavn.ADRESSELINJE2]: '',
 };
 
 function FormWrapper({

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje2Felt.test.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje2Felt.test.tsx
@@ -38,13 +38,9 @@ const visningsnavn = 'Adresselinje 2 (valgfri)';
 
 describe('AdresselinjeFelt', () => {
     test('skal kunne skrive hvis komponenten ikke er i lesevisning', async () => {
-        const { screen, user } = render(
-            <Adresselinje2Felt
-                feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
-                erLesevisning={false}
-            />,
-            { wrapper: FormWrapper }
-        );
+        const { screen, user } = render(<Adresselinje2Felt erLesevisning={false} />, {
+            wrapper: FormWrapper,
+        });
 
         const textbox = screen.getByRole('textbox', { name: visningsnavn });
         await user.click(textbox);
@@ -56,13 +52,9 @@ describe('AdresselinjeFelt', () => {
     });
 
     test('skal ikke kunne skrive hvis komponenten er i lesevisning', async () => {
-        const { screen, user } = render(
-            <Adresselinje2Felt
-                feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
-                erLesevisning={true}
-            />,
-            { wrapper: FormWrapper }
-        );
+        const { screen, user } = render(<Adresselinje2Felt erLesevisning={true} />, {
+            wrapper: FormWrapper,
+        });
 
         const textbox = screen.getByRole('textbox', { name: visningsnavn });
         await user.click(textbox);
@@ -74,10 +66,7 @@ describe('AdresselinjeFelt', () => {
     });
 
     test('skal fokusere som forventet på tekstfeltet når brukeren klikker på tekstfeltet for å så tabbe ut', async () => {
-        const { screen, user } = render(
-            <Adresselinje2Felt feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1} />,
-            { wrapper: FormWrapper }
-        );
+        const { screen, user } = render(<Adresselinje2Felt />, { wrapper: FormWrapper });
 
         const textbox = screen.getByRole('textbox', { name: visningsnavn });
         expect(textbox).not.toHaveFocus();
@@ -88,10 +77,7 @@ describe('AdresselinjeFelt', () => {
     });
 
     test('skal vise maks lengde feilmelding hvis feltet overstiger 80 tegn', async () => {
-        const { screen, user } = render(
-            <Adresselinje2Felt feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1} />,
-            { wrapper: FormWrapper }
-        );
+        const { screen, user } = render(<Adresselinje2Felt />, { wrapper: FormWrapper });
 
         const textbox = screen.getByRole('textbox', { name: visningsnavn });
         await user.click(textbox);
@@ -105,10 +91,7 @@ describe('AdresselinjeFelt', () => {
     });
 
     test('skal ikke vise maks lengde feilmelding hvis feltet inneholder 80 tegn', async () => {
-        const { screen, user } = render(
-            <Adresselinje2Felt feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1} />,
-            { wrapper: FormWrapper }
-        );
+        const { screen, user } = render(<Adresselinje2Felt />, { wrapper: FormWrapper });
 
         const textbox = screen.getByRole('textbox', { name: visningsnavn });
         await user.click(textbox);
@@ -124,32 +107,26 @@ describe('AdresselinjeFelt', () => {
     });
 
     test('skal vise komponent med utfylt verdi fra form state', async () => {
-        const { screen } = render(
-            <Adresselinje2Felt feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1} />,
-            {
-                wrapper: (props) => (
-                    <FormWrapper
-                        {...props}
-                        defaultValues={{
-                            ...DEFAULT_VALUES,
-                            [BrevmottakerFeltnavn.ADRESSELINJE1]: 'Osloveien 1337',
-                        }}
-                    />
-                ),
-            }
-        );
+        const { screen } = render(<Adresselinje2Felt />, {
+            wrapper: (props) => (
+                <FormWrapper
+                    {...props}
+                    defaultValues={{
+                        ...DEFAULT_VALUES,
+                        [BrevmottakerFeltnavn.ADRESSELINJE2]: 'Osloveien 1337',
+                    }}
+                />
+            ),
+        });
 
         const textbox = screen.getByRole('textbox', { name: visningsnavn });
         expect(textbox).toHaveValue('Osloveien 1337');
     });
 
     test('skal ikke kunne skrive hvis formet blir submitted', async () => {
-        const { screen, user } = render(
-            <Adresselinje2Felt feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1} />,
-            {
-                wrapper: (props) => <FormWrapper {...props} onSubmitDelay={3_000} />,
-            }
-        );
+        const { screen, user } = render(<Adresselinje2Felt />, {
+            wrapper: (props) => <FormWrapper {...props} onSubmitDelay={3_000} />,
+        });
 
         const textbox = screen.getByRole('textbox', { name: visningsnavn });
         await user.click(textbox);

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje2Felt.test.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje2Felt.test.tsx
@@ -33,7 +33,7 @@ function FormWrapper({
     );
 }
 
-const visningsnavn = 'Adresselinje 2 (valgfri)';
+const label = 'Adresselinje 2 (valgfri)';
 
 describe('AdresselinjeFelt', () => {
     test('skal kunne skrive hvis komponenten ikke er i lesevisning', async () => {
@@ -41,7 +41,7 @@ describe('AdresselinjeFelt', () => {
             wrapper: FormWrapper,
         });
 
-        const textbox = screen.getByRole('textbox', { name: visningsnavn });
+        const textbox = screen.getByRole('textbox', { name: label });
         await user.click(textbox);
         await user.keyboard('Dette er en prøve');
 
@@ -55,7 +55,7 @@ describe('AdresselinjeFelt', () => {
             wrapper: FormWrapper,
         });
 
-        const textbox = screen.getByRole('textbox', { name: visningsnavn });
+        const textbox = screen.getByRole('textbox', { name: label });
         await user.click(textbox);
         await user.keyboard('Dette er en prøve');
 
@@ -67,7 +67,7 @@ describe('AdresselinjeFelt', () => {
     test('skal fokusere som forventet på tekstfeltet når brukeren klikker på tekstfeltet for å så tabbe ut', async () => {
         const { screen, user } = render(<Adresselinje2Felt />, { wrapper: FormWrapper });
 
-        const textbox = screen.getByRole('textbox', { name: visningsnavn });
+        const textbox = screen.getByRole('textbox', { name: label });
         expect(textbox).not.toHaveFocus();
         await user.click(textbox);
         expect(textbox).toHaveFocus();
@@ -78,30 +78,28 @@ describe('AdresselinjeFelt', () => {
     test('skal vise maks lengde feilmelding hvis feltet overstiger 80 tegn', async () => {
         const { screen, user } = render(<Adresselinje2Felt />, { wrapper: FormWrapper });
 
-        const textbox = screen.getByRole('textbox', { name: visningsnavn });
+        const textbox = screen.getByRole('textbox', { name: label });
         await user.click(textbox);
         await user.keyboard(
             'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligulade'
         );
         await user.tab();
 
-        const feilmelding = screen.getByText(`${visningsnavn} kan ikke inneholde mer enn 80 tegn.`);
+        const feilmelding = screen.getByText(`${label} kan ikke inneholde mer enn 80 tegn.`);
         expect(feilmelding).toBeInTheDocument();
     });
 
     test('skal ikke vise maks lengde feilmelding hvis feltet inneholder 80 tegn', async () => {
         const { screen, user } = render(<Adresselinje2Felt />, { wrapper: FormWrapper });
 
-        const textbox = screen.getByRole('textbox', { name: visningsnavn });
+        const textbox = screen.getByRole('textbox', { name: label });
         await user.click(textbox);
         await user.keyboard(
             'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligulaa'
         );
         await user.tab();
 
-        const feilmelding = screen.queryByText(
-            `${visningsnavn} kan ikke inneholde mer enn 80 tegn.`
-        );
+        const feilmelding = screen.queryByText(`${label} kan ikke inneholde mer enn 80 tegn.`);
         expect(feilmelding).not.toBeInTheDocument();
     });
 
@@ -118,7 +116,7 @@ describe('AdresselinjeFelt', () => {
             ),
         });
 
-        const textbox = screen.getByRole('textbox', { name: visningsnavn });
+        const textbox = screen.getByRole('textbox', { name: label });
         expect(textbox).toHaveValue('Osloveien 1337');
     });
 
@@ -127,7 +125,7 @@ describe('AdresselinjeFelt', () => {
             wrapper: (props) => <FormWrapper {...props} onSubmitDelay={3_000} />,
         });
 
-        const textbox = screen.getByRole('textbox', { name: visningsnavn });
+        const textbox = screen.getByRole('textbox', { name: label });
         await user.click(textbox);
         await user.keyboard('abc');
 

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje2Felt.test.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje2Felt.test.tsx
@@ -1,0 +1,188 @@
+import React from 'react';
+
+import { describe, expect, test } from 'vitest';
+import { Adresselinje2Felt } from './Adresselinje2Felt';
+import { BrevmottakerFeltnavn } from './felttyper';
+import { DefaultValues, FormProvider, useForm } from 'react-hook-form';
+import { BrevmottakerFormValues } from '../BrevmottakerForm';
+import { render } from '../../../../../../../lib/testrender';
+import { Button } from '@navikt/ds-react';
+
+const onSubmit = (delay: number) => new Promise((resolve) => setTimeout(resolve, delay));
+
+const DEFAULT_VALUES: DefaultValues<BrevmottakerFormValues> = {
+    [BrevmottakerFeltnavn.ADRESSELINJE1]: '',
+};
+
+function FormWrapper({
+    children,
+    defaultValues = DEFAULT_VALUES,
+    onSubmitDelay = 0,
+}: {
+    children: React.ReactNode;
+    defaultValues?: DefaultValues<BrevmottakerFormValues>;
+    onSubmitDelay?: number;
+}) {
+    const form = useForm<BrevmottakerFormValues>({ mode: 'onChange', defaultValues });
+    return (
+        <FormProvider {...form}>
+            <form onSubmit={form.handleSubmit(() => onSubmit(onSubmitDelay))}>
+                {children}
+                <Button type={'submit'}>Submit</Button>
+            </form>
+        </FormProvider>
+    );
+}
+
+const visningsnavn = 'Adresselinje 1';
+
+describe('AdresselinjeFelt', () => {
+    test('skal kunne skrive hvis komponenten ikke er i lesevisning', async () => {
+        const { screen, user } = render(
+            <Adresselinje2Felt
+                feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
+                visningsnavn={visningsnavn}
+                erLesevisning={false}
+            />,
+            { wrapper: FormWrapper }
+        );
+
+        const textbox = screen.getByRole('textbox', { name: visningsnavn });
+        await user.click(textbox);
+        await user.keyboard('Dette er en prøve');
+
+        expect(textbox).toBeInTheDocument();
+        expect(textbox).not.toHaveAttribute('readonly');
+        expect(textbox).toHaveValue('Dette er en prøve');
+    });
+
+    test('skal ikke kunne skrive hvis komponenten er i lesevisning', async () => {
+        const { screen, user } = render(
+            <Adresselinje2Felt
+                feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
+                visningsnavn={visningsnavn}
+                erLesevisning={true}
+            />,
+            { wrapper: FormWrapper }
+        );
+
+        const textbox = screen.getByRole('textbox', { name: visningsnavn });
+        await user.click(textbox);
+        await user.keyboard('Dette er en prøve');
+
+        expect(textbox).toHaveValue('');
+        expect(textbox).toBeInTheDocument();
+        expect(textbox).toHaveAttribute('readonly');
+    });
+
+    test('skal fokusere som forventet på tekstfeltet når brukeren klikker på tekstfeltet for å så tabbe ut', async () => {
+        const { screen, user } = render(
+            <Adresselinje2Felt
+                feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
+                visningsnavn={visningsnavn}
+            />,
+            { wrapper: FormWrapper }
+        );
+
+        const textbox = screen.getByRole('textbox', { name: visningsnavn });
+        expect(textbox).not.toHaveFocus();
+        await user.click(textbox);
+        expect(textbox).toHaveFocus();
+        await user.tab();
+        expect(textbox).not.toHaveFocus();
+    });
+
+    test('skal vise maks lengde feilmelding hvis feltet overstiger 80 tegn', async () => {
+        const { screen, user } = render(
+            <Adresselinje2Felt
+                feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
+                visningsnavn={visningsnavn}
+            />,
+            { wrapper: FormWrapper }
+        );
+
+        const textbox = screen.getByRole('textbox', { name: visningsnavn });
+        await user.click(textbox);
+        await user.keyboard(
+            'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligulade'
+        );
+        await user.tab();
+
+        const feilmelding = screen.getByText(`${visningsnavn} kan ikke inneholde mer enn 80 tegn.`);
+        expect(feilmelding).toBeInTheDocument();
+    });
+
+    test('skal ikke vise maks lengde feilmelding hvis feltet inneholder 80 tegn', async () => {
+        const { screen, user } = render(
+            <Adresselinje2Felt
+                feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
+                visningsnavn={visningsnavn}
+            />,
+            { wrapper: FormWrapper }
+        );
+
+        const textbox = screen.getByRole('textbox', { name: visningsnavn });
+        await user.click(textbox);
+        await user.keyboard(
+            'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligulaa'
+        );
+        await user.tab();
+
+        const feilmelding = screen.queryByText(
+            `${visningsnavn} kan ikke inneholde mer enn 80 tegn.`
+        );
+        expect(feilmelding).not.toBeInTheDocument();
+    });
+
+    test('skal vise komponent med utfylt verdi fra form state', async () => {
+        const { screen } = render(
+            <Adresselinje2Felt
+                feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
+                visningsnavn={visningsnavn}
+            />,
+            {
+                wrapper: (props) => (
+                    <FormWrapper
+                        {...props}
+                        defaultValues={{
+                            ...DEFAULT_VALUES,
+                            [BrevmottakerFeltnavn.ADRESSELINJE1]: 'Osloveien 1337',
+                        }}
+                    />
+                ),
+            }
+        );
+
+        const textbox = screen.getByRole('textbox', { name: visningsnavn });
+        expect(textbox).toHaveValue('Osloveien 1337');
+    });
+
+    test('skal ikke kunne skrive hvis formet blir submitted', async () => {
+        const { screen, user } = render(
+            <Adresselinje2Felt
+                feltnavn={BrevmottakerFeltnavn.ADRESSELINJE1}
+                visningsnavn={visningsnavn}
+            />,
+            {
+                wrapper: (props) => <FormWrapper {...props} onSubmitDelay={3_000} />,
+            }
+        );
+
+        const textbox = screen.getByRole('textbox', { name: visningsnavn });
+        await user.click(textbox);
+        await user.keyboard('abc');
+
+        expect(textbox).toHaveValue('abc');
+        expect(textbox).toBeInTheDocument();
+        expect(textbox).not.toHaveAttribute('readonly');
+
+        const submitButton = screen.getByRole('button', { name: 'Submit' });
+        await user.click(submitButton);
+        await user.click(textbox);
+        await user.keyboard('123');
+
+        expect(textbox).toHaveValue('abc');
+        expect(textbox).toBeInTheDocument();
+        expect(textbox).toHaveAttribute('readonly');
+    });
+});

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje2Felt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje2Felt.tsx
@@ -1,18 +1,20 @@
 import { useController, useFormContext } from 'react-hook-form';
 import React from 'react';
 import { TextField } from '@navikt/ds-react';
-import { BrevmottakerFeltProps } from './felttyper';
+import { BrevmottakerFeltnavn } from './felttyper';
 import { BrevmottakerFormValues } from '../BrevmottakerForm';
 
-type Props = BrevmottakerFeltProps & {};
+interface Props {
+    erLesevisning?: boolean;
+}
 
 const visningsnavn = 'Adresselinje 2 (valgfri)';
 
-export function Adresselinje2Felt({ feltnavn, erLesevisning = false }: Props) {
+export function Adresselinje2Felt({ erLesevisning = false }: Props) {
     const { control } = useFormContext<BrevmottakerFormValues>();
 
     const { field, fieldState, formState } = useController({
-        name: feltnavn,
+        name: BrevmottakerFeltnavn.ADRESSELINJE2,
         control,
         rules: {
             maxLength: {

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje2Felt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje2Felt.tsx
@@ -1,8 +1,7 @@
 import { useController, useFormContext } from 'react-hook-form';
 import React from 'react';
 import { TextField } from '@navikt/ds-react';
-import { BrevmottakerFeltnavn } from './felttyper';
-import { BrevmottakerFormValues } from '../BrevmottakerForm';
+import { BrevmottakerFeltnavn, BrevmottakerFormValues } from '../BrevmottakerForm';
 
 interface Props {
     erLesevisning?: boolean;

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje2Felt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje2Felt.tsx
@@ -23,15 +23,13 @@ export function Adresselinje2Felt({ erLesevisning = false }: Props) {
         },
     });
 
-    const visFeilmelding = fieldState.isTouched || formState.isSubmitted;
-
     return (
         <TextField
             label={visningsnavn}
             value={field.value}
             onBlur={field.onBlur}
             onChange={field.onChange}
-            error={visFeilmelding && fieldState.error?.message}
+            error={fieldState.error?.message}
             readOnly={erLesevisning || formState.isSubmitting}
         />
     );

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje2Felt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje2Felt.tsx
@@ -5,7 +5,9 @@ import { BrevmottakerFeltProps } from './felttyper';
 
 type Props = BrevmottakerFeltProps & {};
 
-export function Adresselinje2Felt({ feltnavn, visningsnavn, erLesevisning = false }: Props) {
+const visningsnavn = 'Adresselinje 2 (valgfri)';
+
+export function Adresselinje2Felt({ feltnavn, erLesevisning = false }: Props) {
     const { control } = useFormContext();
 
     const { field, fieldState, formState } = useController({

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje2Felt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje2Felt.tsx
@@ -2,13 +2,14 @@ import { useController, useFormContext } from 'react-hook-form';
 import React from 'react';
 import { TextField } from '@navikt/ds-react';
 import { BrevmottakerFeltProps } from './felttyper';
+import { BrevmottakerFormValues } from '../BrevmottakerForm';
 
 type Props = BrevmottakerFeltProps & {};
 
 const visningsnavn = 'Adresselinje 2 (valgfri)';
 
 export function Adresselinje2Felt({ feltnavn, erLesevisning = false }: Props) {
-    const { control } = useFormContext();
+    const { control } = useFormContext<BrevmottakerFormValues>();
 
     const { field, fieldState, formState } = useController({
         name: feltnavn,

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje2Felt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje2Felt.tsx
@@ -7,7 +7,7 @@ interface Props {
     erLesevisning?: boolean;
 }
 
-const visningsnavn = 'Adresselinje 2 (valgfri)';
+const label = 'Adresselinje 2 (valgfri)';
 
 export function Adresselinje2Felt({ erLesevisning = false }: Props) {
     const { control } = useFormContext<BrevmottakerFormValues>();
@@ -18,14 +18,14 @@ export function Adresselinje2Felt({ erLesevisning = false }: Props) {
         rules: {
             maxLength: {
                 value: 80,
-                message: `${visningsnavn} kan ikke inneholde mer enn 80 tegn.`,
+                message: `${label} kan ikke inneholde mer enn 80 tegn.`,
             },
         },
     });
 
     return (
         <TextField
-            label={visningsnavn}
+            label={label}
             value={field.value}
             onBlur={field.onBlur}
             onChange={field.onChange}

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje2Felt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/Adresselinje2Felt.tsx
@@ -3,25 +3,15 @@ import React from 'react';
 import { TextField } from '@navikt/ds-react';
 import { BrevmottakerFeltProps } from './felttyper';
 
-type Props = BrevmottakerFeltProps & {
-    valgfri?: boolean;
-    beskrivelse?: React.ReactNode;
-};
+type Props = BrevmottakerFeltProps & {};
 
-export function AdresselinjeFelt({
-    feltnavn,
-    visningsnavn,
-    valgfri = true,
-    beskrivelse = null,
-    erLesevisning = false,
-}: Props) {
+export function Adresselinje2Felt({ feltnavn, visningsnavn, erLesevisning = false }: Props) {
     const { control } = useFormContext();
 
     const { field, fieldState, formState } = useController({
         name: feltnavn,
         control,
         rules: {
-            required: !valgfri ? `${visningsnavn} er påkrevd.` : undefined,
             maxLength: {
                 value: 80,
                 message: `${visningsnavn} kan ikke inneholde mer enn 80 tegn.`,
@@ -38,7 +28,6 @@ export function AdresselinjeFelt({
             onBlur={field.onBlur}
             onChange={field.onChange}
             error={visFeilmelding && fieldState.error?.message}
-            description={beskrivelse}
             readOnly={erLesevisning || formState.isSubmitting}
         />
     );

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/AdresselinjeFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/AdresselinjeFelt.tsx
@@ -1,4 +1,4 @@
-import { Controller, useFormContext } from 'react-hook-form';
+import { useController, useFormContext } from 'react-hook-form';
 import React from 'react';
 import { TextField } from '@navikt/ds-react';
 import { BrevmottakerFeltProps } from './felttyper';
@@ -15,32 +15,31 @@ export function AdresselinjeFelt({
     beskrivelse = null,
     erLesevisning = false,
 }: Props) {
-    const { control, formState } = useFormContext();
+    const { control } = useFormContext();
+
+    const { field, fieldState, formState } = useController({
+        name: feltnavn,
+        control,
+        rules: {
+            required: !valgfri ? `${visningsnavn} er påkrevd.` : undefined,
+            maxLength: {
+                value: 80,
+                message: `${visningsnavn} kan ikke inneholde mer enn 80 tegn.`,
+            },
+        },
+    });
+
+    const visFeilmelding = fieldState.isTouched || formState.isSubmitted;
+
     return (
-        <Controller
-            control={control}
-            name={feltnavn}
-            rules={{
-                required: !valgfri ? `${visningsnavn} er påkrevd.` : undefined,
-                maxLength: {
-                    value: 80,
-                    message: `${visningsnavn} kan ikke inneholde mer enn 80 tegn.`,
-                },
-            }}
-            render={({ field, fieldState }) => {
-                const visFeilmelding = fieldState.isTouched || formState.isSubmitted;
-                return (
-                    <TextField
-                        label={visningsnavn}
-                        value={field.value}
-                        onBlur={field.onBlur}
-                        onChange={field.onChange}
-                        error={visFeilmelding && fieldState.error?.message}
-                        description={beskrivelse}
-                        readOnly={erLesevisning || formState.isSubmitting}
-                    />
-                );
-            }}
+        <TextField
+            label={visningsnavn}
+            value={field.value}
+            onBlur={field.onBlur}
+            onChange={field.onChange}
+            error={visFeilmelding && fieldState.error?.message}
+            description={beskrivelse}
+            readOnly={erLesevisning || formState.isSubmitting}
         />
     );
 }

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/LandFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/LandFelt.tsx
@@ -11,7 +11,7 @@ interface Props {
     erLesevisning?: boolean;
 }
 
-const visningsnavn = 'Land';
+const label = 'Land';
 
 export function LandFelt({ personopplysninger, erLesevisning = false }: Props) {
     const { control, getValues, setValue } = useFormContext<BrevmottakerFormValues>();
@@ -22,7 +22,7 @@ export function LandFelt({ personopplysninger, erLesevisning = false }: Props) {
         rules: {
             validate: (landkode) => {
                 if (landkode === '') {
-                    return `${visningsnavn} er påkrevd.`;
+                    return `${label} er påkrevd.`;
                 }
                 const mottakerRolle = getValues(BrevmottakerFeltnavn.MOTTAKERROLLE);
                 if (mottakerRolle === '') {
@@ -39,7 +39,7 @@ export function LandFelt({ personopplysninger, erLesevisning = false }: Props) {
 
     return (
         <EøsLandvelger
-            label={visningsnavn}
+            label={label}
             onBlur={field.onBlur}
             value={field.value}
             onToggleSelected={(value, isSelected) => {

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/LandFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/LandFelt.tsx
@@ -5,6 +5,7 @@ import { IPersonopplysninger } from '../../../../../../../App/typer/personopplys
 import { erGyldigMottakerRolleForLandkode, MottakerRolle } from '../../../../mottakerRolle';
 import { utledBrevmottakerPersonUtenIdentNavnVedDødsbo } from '../../../../brevmottaker';
 import { BrevmottakerFeltnavn, BrevmottakerFormValues } from '../BrevmottakerForm';
+import { erEøsLandkode } from '../../../../../../../Felles/Landvelger/landkode';
 
 interface Props {
     personopplysninger: IPersonopplysninger;
@@ -38,20 +39,19 @@ export function LandFelt({ personopplysninger, erLesevisning = false }: Props) {
     });
 
     function onToggleSelected(value: string, isSelected: boolean) {
-        const landkode = value as BrevmottakerFormValues[BrevmottakerFeltnavn.LANDKODE];
-        const harValgtLand = landkode !== '';
-
-        const erDødsbo = getValues(BrevmottakerFeltnavn.MOTTAKERROLLE) === MottakerRolle.DØDSBO;
-
-        if (isSelected && erDødsbo && harValgtLand) {
-            const nyttNavn = utledBrevmottakerPersonUtenIdentNavnVedDødsbo(
-                personopplysninger.navn,
-                landkode
-            );
-            setValue(BrevmottakerFeltnavn.NAVN, nyttNavn);
+        if (!isSelected || !erEøsLandkode(value)) {
+            field.onChange('');
+            return;
         }
-
-        field.onChange(isSelected ? landkode : '');
+        const mottakerRolle = getValues(BrevmottakerFeltnavn.MOTTAKERROLLE);
+        if (mottakerRolle === MottakerRolle.DØDSBO) {
+            const nyttPreutfyltNavn = utledBrevmottakerPersonUtenIdentNavnVedDødsbo(
+                personopplysninger.navn,
+                value
+            );
+            setValue(BrevmottakerFeltnavn.NAVN, nyttPreutfyltNavn);
+        }
+        field.onChange(value);
     }
 
     return (

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/LandFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/LandFelt.tsx
@@ -1,24 +1,25 @@
 import React from 'react';
 import { useController, useFormContext } from 'react-hook-form';
 import { EøsLandvelger } from '../../../../../../../Felles/Landvelger/EøsLandvelger';
-import { BrevmottakerFeltnavn, BrevmottakerFeltProps } from './felttyper';
+import { BrevmottakerFeltnavn } from './felttyper';
 import { IPersonopplysninger } from '../../../../../../../App/typer/personopplysninger';
 import { erGyldigMottakerRolleForLandkode, MottakerRolle } from '../../../../mottakerRolle';
 import { utledBrevmottakerPersonUtenIdentNavnVedDødsbo } from '../../../../brevmottaker';
 import { BrevmottakerFormValues } from '../BrevmottakerForm';
 import { EøsLandkode } from '../../../../../../../Felles/Landvelger/landkode';
 
-type Props = BrevmottakerFeltProps & {
+interface Props {
     personopplysninger: IPersonopplysninger;
-};
+    erLesevisning?: boolean;
+}
 
 const visningsnavn = 'Land';
 
-export function LandFelt({ feltnavn, erLesevisning, personopplysninger }: Props) {
+export function LandFelt({ personopplysninger, erLesevisning = false }: Props) {
     const { control, getValues, setValue } = useFormContext<BrevmottakerFormValues>();
 
     const { field, fieldState, formState } = useController({
-        name: feltnavn,
+        name: BrevmottakerFeltnavn.LANDKODE,
         control,
         rules: {
             validate: (landkode) => {

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/LandFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/LandFelt.tsx
@@ -37,23 +37,29 @@ export function LandFelt({ personopplysninger, erLesevisning = false }: Props) {
         },
     });
 
+    function onToggleSelected(value: string, isSelected: boolean) {
+        const landkode = value as BrevmottakerFormValues[BrevmottakerFeltnavn.LANDKODE];
+        const harValgtLand = landkode !== '';
+
+        const erDødsbo = getValues(BrevmottakerFeltnavn.MOTTAKERROLLE) === MottakerRolle.DØDSBO;
+
+        if (isSelected && erDødsbo && harValgtLand) {
+            const nyttNavn = utledBrevmottakerPersonUtenIdentNavnVedDødsbo(
+                personopplysninger.navn,
+                landkode
+            );
+            setValue(BrevmottakerFeltnavn.NAVN, nyttNavn);
+        }
+
+        field.onChange(isSelected ? landkode : '');
+    }
+
     return (
         <EøsLandvelger
             label={label}
             onBlur={field.onBlur}
             value={field.value}
-            onToggleSelected={(value, isSelected) => {
-                const landkode = value as BrevmottakerFormValues[BrevmottakerFeltnavn.LANDKODE];
-                const mottakerRolle = getValues(BrevmottakerFeltnavn.MOTTAKERROLLE);
-                if (isSelected && mottakerRolle === MottakerRolle.DØDSBO && landkode !== '') {
-                    const nyttNavn = utledBrevmottakerPersonUtenIdentNavnVedDødsbo(
-                        personopplysninger.navn,
-                        landkode
-                    );
-                    setValue(BrevmottakerFeltnavn.NAVN, nyttNavn);
-                }
-                field.onChange(isSelected ? landkode : '');
-            }}
+            onToggleSelected={onToggleSelected}
             error={fieldState.error?.message}
             readOnly={erLesevisning || formState.isSubmitting}
         />

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/LandFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/LandFelt.tsx
@@ -5,7 +5,6 @@ import { IPersonopplysninger } from '../../../../../../../App/typer/personopplys
 import { erGyldigMottakerRolleForLandkode, MottakerRolle } from '../../../../mottakerRolle';
 import { utledBrevmottakerPersonUtenIdentNavnVedDødsbo } from '../../../../brevmottaker';
 import { BrevmottakerFeltnavn, BrevmottakerFormValues } from '../BrevmottakerForm';
-import { EøsLandkode } from '../../../../../../../Felles/Landvelger/landkode';
 
 interface Props {
     personopplysninger: IPersonopplysninger;
@@ -29,7 +28,7 @@ export function LandFelt({ personopplysninger, erLesevisning = false }: Props) {
                 if (mottakerRolle === '') {
                     return undefined;
                 }
-                if (!erGyldigMottakerRolleForLandkode(mottakerRolle, landkode as EøsLandkode)) {
+                if (!erGyldigMottakerRolleForLandkode(mottakerRolle, landkode)) {
                     return 'Norge kan ikke være satt for bruker med utenlandsk adresse.';
                 }
                 return undefined;
@@ -46,16 +45,16 @@ export function LandFelt({ personopplysninger, erLesevisning = false }: Props) {
             onBlur={field.onBlur}
             value={field.value}
             onToggleSelected={(value, isSelected) => {
+                const landkode = value as BrevmottakerFormValues[BrevmottakerFeltnavn.LANDKODE];
                 const mottakerRolle = getValues(BrevmottakerFeltnavn.MOTTAKERROLLE);
-                if (isSelected && mottakerRolle === MottakerRolle.DØDSBO) {
-                    const landkode = EøsLandkode[value as keyof typeof EøsLandkode];
+                if (isSelected && mottakerRolle === MottakerRolle.DØDSBO && landkode !== '') {
                     const nyttNavn = utledBrevmottakerPersonUtenIdentNavnVedDødsbo(
                         personopplysninger.navn,
                         landkode
                     );
                     setValue(BrevmottakerFeltnavn.NAVN, nyttNavn);
                 }
-                field.onChange(isSelected ? value : '');
+                field.onChange(isSelected ? landkode : '');
             }}
             error={visFeilmelding && fieldState.error?.message}
             readOnly={erLesevisning || formState.isSubmitting}

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/LandFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/LandFelt.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { useController, useFormContext } from 'react-hook-form';
 import { EøsLandvelger } from '../../../../../../../Felles/Landvelger/EøsLandvelger';
-import { BrevmottakerFeltnavn } from './felttyper';
 import { IPersonopplysninger } from '../../../../../../../App/typer/personopplysninger';
 import { erGyldigMottakerRolleForLandkode, MottakerRolle } from '../../../../mottakerRolle';
 import { utledBrevmottakerPersonUtenIdentNavnVedDødsbo } from '../../../../brevmottaker';
-import { BrevmottakerFormValues } from '../BrevmottakerForm';
+import { BrevmottakerFeltnavn, BrevmottakerFormValues } from '../BrevmottakerForm';
 import { EøsLandkode } from '../../../../../../../Felles/Landvelger/landkode';
 
 interface Props {

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/LandFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/LandFelt.tsx
@@ -10,7 +10,9 @@ type Props = BrevmottakerFeltProps & {
     personopplysninger: IPersonopplysninger;
 };
 
-export function LandFelt({ feltnavn, visningsnavn, erLesevisning, personopplysninger }: Props) {
+const visningsnavn = 'Land';
+
+export function LandFelt({ feltnavn, erLesevisning, personopplysninger }: Props) {
     const { control, getValues, setValue } = useFormContext();
 
     const { field, fieldState, formState } = useController({

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/LandFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/LandFelt.tsx
@@ -37,8 +37,6 @@ export function LandFelt({ personopplysninger, erLesevisning = false }: Props) {
         },
     });
 
-    const visFeilmelding = fieldState.isTouched || formState.isSubmitted;
-
     return (
         <EøsLandvelger
             label={visningsnavn}
@@ -56,7 +54,7 @@ export function LandFelt({ personopplysninger, erLesevisning = false }: Props) {
                 }
                 field.onChange(isSelected ? landkode : '');
             }}
-            error={visFeilmelding && fieldState.error?.message}
+            error={fieldState.error?.message}
             readOnly={erLesevisning || formState.isSubmitting}
         />
     );

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/MottakerFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/MottakerFelt.tsx
@@ -3,9 +3,10 @@ import { Select } from '@navikt/ds-react';
 import { useController, useFormContext } from 'react-hook-form';
 import { IPersonopplysninger } from '../../../../../../../App/typer/personopplysninger';
 import {
+    BlankMottakerRolle,
     MottakerRolle,
     mottakerRolleVisningsnavn,
-    skalNavnVærePreutfyltForMottakerRolle,
+    skalPreutfylleNavnForMottakerRolle,
 } from '../../../../mottakerRolle';
 import {
     BrevmottakerPersonUtenIdent,
@@ -35,22 +36,20 @@ export function MottakerFelt({ personopplysninger, brevmottakere, erLesevisning 
         },
     });
 
-    function oppdatertNavnForMottakerRolleHvisNødvendig(nyMottakerRolle: MottakerRolle | '') {
+    function oppdatertNavnForMottakerRolleHvisNødvendig(
+        nyMottakerRolle: MottakerRolle | BlankMottakerRolle
+    ) {
         const landkode = getValues(BrevmottakerFeltnavn.LANDKODE);
         const forrigeMottakerRolle = getValues(BrevmottakerFeltnavn.MOTTAKERROLLE);
 
-        const varNavnPreutfylt =
-            forrigeMottakerRolle !== '' &&
-            skalNavnVærePreutfyltForMottakerRolle(forrigeMottakerRolle);
-
-        const skalNavnPreutfylles =
-            nyMottakerRolle !== '' && skalNavnVærePreutfyltForMottakerRolle(nyMottakerRolle);
+        const varNavnPreutfylt = skalPreutfylleNavnForMottakerRolle(forrigeMottakerRolle);
+        const skalNavnPreutfylles = skalPreutfylleNavnForMottakerRolle(nyMottakerRolle);
 
         if (varNavnPreutfylt && !skalNavnPreutfylles) {
             setValue(BrevmottakerFeltnavn.NAVN, '');
         }
 
-        if (skalNavnPreutfylles) {
+        if (skalNavnPreutfylles && nyMottakerRolle !== '') {
             const nyttNavn = utledPreutfyltBrevmottakerPersonUtenIdentNavn(
                 personopplysninger.navn,
                 landkode === '' ? EøsLandkode.NO : landkode,
@@ -66,8 +65,9 @@ export function MottakerFelt({ personopplysninger, brevmottakere, erLesevisning 
             value={field.value}
             onBlur={field.onBlur}
             onChange={(event) => {
-                const nyMottakerRolle = event.target
-                    .value as BrevmottakerFormValues[BrevmottakerFeltnavn.MOTTAKERROLLE];
+                const value = event.target.value;
+                const nyMottakerRolle =
+                    value as BrevmottakerFormValues[BrevmottakerFeltnavn.MOTTAKERROLLE];
                 oppdatertNavnForMottakerRolleHvisNødvendig(nyMottakerRolle);
                 field.onChange(nyMottakerRolle);
             }}

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/MottakerFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/MottakerFelt.tsx
@@ -3,18 +3,15 @@ import { Select } from '@navikt/ds-react';
 import { useController, useFormContext } from 'react-hook-form';
 import { IPersonopplysninger } from '../../../../../../../App/typer/personopplysninger';
 import {
-    BlankMottakerRolle,
-    MottakerRolle,
+    erMottakerRolle,
+    finnNyttBrevmottakernavnHvisNødvendigVedEndringAvMottakerRolle,
     mottakerRolleVisningsnavn,
-    skalPreutfylleNavnForMottakerRolle,
 } from '../../../../mottakerRolle';
 import {
     BrevmottakerPersonUtenIdent,
     utledGyldigeMottakerRolleForBrevmottakerPersonUtenIdent,
-    utledPreutfyltBrevmottakerPersonUtenIdentNavn,
 } from '../../../../brevmottaker';
 import { BrevmottakerFeltnavn, BrevmottakerFormValues } from '../BrevmottakerForm';
-import { EøsLandkode } from '../../../../../../../Felles/Landvelger/landkode';
 
 interface Props {
     personopplysninger: IPersonopplysninger;
@@ -36,34 +33,26 @@ export function MottakerFelt({ personopplysninger, brevmottakere, erLesevisning 
         },
     });
 
-    function oppdaterBrevmottakernavnBasertPåMottakerRolleHvisNødvendig(
-        nyMottakerRolle: MottakerRolle | BlankMottakerRolle
-    ) {
-        const landkode = getValues(BrevmottakerFeltnavn.LANDKODE);
-        const forrigeMottakerRolle = getValues(BrevmottakerFeltnavn.MOTTAKERROLLE);
-
-        const varNavnPreutfylt = skalPreutfylleNavnForMottakerRolle(forrigeMottakerRolle);
-        const skalNavnPreutfylles = skalPreutfylleNavnForMottakerRolle(nyMottakerRolle);
-
-        if (varNavnPreutfylt && !skalNavnPreutfylles) {
-            setValue(BrevmottakerFeltnavn.NAVN, '');
-        }
-
-        if (skalNavnPreutfylles && nyMottakerRolle !== '') {
-            const nyttNavn = utledPreutfyltBrevmottakerPersonUtenIdentNavn(
-                personopplysninger.navn,
-                landkode === '' ? EøsLandkode.NO : landkode,
-                nyMottakerRolle
-            );
-            setValue(BrevmottakerFeltnavn.NAVN, nyttNavn);
-        }
-    }
-
     function onChange(event: ChangeEvent<HTMLSelectElement>) {
         const value = event.target.value;
-        const nyMottakerRolle = value as BrevmottakerFormValues[BrevmottakerFeltnavn.MOTTAKERROLLE];
-        oppdaterBrevmottakernavnBasertPåMottakerRolleHvisNødvendig(nyMottakerRolle);
-        field.onChange(nyMottakerRolle);
+        if (erMottakerRolle(value)) {
+            const nyMottakerRolle = value;
+            const forrigeMottakerRolle = getValues(BrevmottakerFeltnavn.MOTTAKERROLLE);
+            const landkode = getValues(BrevmottakerFeltnavn.LANDKODE);
+            const nyttBrevmottakernavn =
+                finnNyttBrevmottakernavnHvisNødvendigVedEndringAvMottakerRolle(
+                    nyMottakerRolle,
+                    forrigeMottakerRolle,
+                    landkode,
+                    personopplysninger
+                );
+            if (nyttBrevmottakernavn !== undefined) {
+                setValue(BrevmottakerFeltnavn.NAVN, nyttBrevmottakernavn);
+            }
+            field.onChange(value);
+        } else {
+            field.onChange('');
+        }
     }
 
     return (

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/MottakerFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/MottakerFelt.tsx
@@ -19,9 +19,10 @@ type Props = BrevmottakerFeltProps & {
     brevmottakere: BrevmottakerPersonUtenIdent[];
 };
 
+const visningsnavn = 'Mottaker';
+
 export function MottakerFelt({
     feltnavn,
-    visningsnavn,
     personopplysninger,
     brevmottakere,
     erLesevisning,

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/MottakerFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/MottakerFelt.tsx
@@ -36,7 +36,7 @@ export function MottakerFelt({ personopplysninger, brevmottakere, erLesevisning 
         },
     });
 
-    function oppdatertNavnForMottakerRolleHvisNødvendig(
+    function oppdaterBrevmottakernavnBasertPåMottakerRolleHvisNødvendig(
         nyMottakerRolle: MottakerRolle | BlankMottakerRolle
     ) {
         const landkode = getValues(BrevmottakerFeltnavn.LANDKODE);
@@ -62,7 +62,7 @@ export function MottakerFelt({ personopplysninger, brevmottakere, erLesevisning 
     function onChange(event: ChangeEvent<HTMLSelectElement>) {
         const value = event.target.value;
         const nyMottakerRolle = value as BrevmottakerFormValues[BrevmottakerFeltnavn.MOTTAKERROLLE];
-        oppdatertNavnForMottakerRolleHvisNødvendig(nyMottakerRolle);
+        oppdaterBrevmottakernavnBasertPåMottakerRolleHvisNødvendig(nyMottakerRolle);
         field.onChange(nyMottakerRolle);
     }
 

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/MottakerFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/MottakerFelt.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Select } from '@navikt/ds-react';
 import { useController, useFormContext } from 'react-hook-form';
 import { IPersonopplysninger } from '../../../../../../../App/typer/personopplysninger';
-import { BrevmottakerFeltnavn } from './felttyper';
 import {
     MottakerRolle,
     mottakerRolleVisningsnavn,
@@ -13,7 +12,7 @@ import {
     utledGyldigeMottakerRolleForBrevmottakerPersonUtenIdent,
     utledPreutfyltBrevmottakerPersonUtenIdentNavn,
 } from '../../../../brevmottaker';
-import { BrevmottakerFormValues } from '../BrevmottakerForm';
+import { BrevmottakerFeltnavn, BrevmottakerFormValues } from '../BrevmottakerForm';
 import { EøsLandkode } from '../../../../../../../Felles/Landvelger/landkode';
 
 interface Props {

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/MottakerFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/MottakerFelt.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Select } from '@navikt/ds-react';
 import { useController, useFormContext } from 'react-hook-form';
 import { IPersonopplysninger } from '../../../../../../../App/typer/personopplysninger';
-import { BrevmottakerFeltnavn, BrevmottakerFeltProps } from './felttyper';
+import { BrevmottakerFeltnavn } from './felttyper';
 import {
     MottakerRolle,
     mottakerRolleVisningsnavn,
@@ -16,23 +16,19 @@ import {
 import { BrevmottakerFormValues } from '../BrevmottakerForm';
 import { EøsLandkode } from '../../../../../../../Felles/Landvelger/landkode';
 
-type Props = BrevmottakerFeltProps & {
+interface Props {
     personopplysninger: IPersonopplysninger;
     brevmottakere: BrevmottakerPersonUtenIdent[];
-};
+    erLesevisning?: boolean;
+}
 
 const visningsnavn = 'Mottaker';
 
-export function MottakerFelt({
-    feltnavn,
-    personopplysninger,
-    brevmottakere,
-    erLesevisning,
-}: Props) {
+export function MottakerFelt({ personopplysninger, brevmottakere, erLesevisning = false }: Props) {
     const { control, setValue, getValues } = useFormContext<BrevmottakerFormValues>();
 
     const { field, fieldState, formState } = useController({
-        name: feltnavn,
+        name: BrevmottakerFeltnavn.MOTTAKERROLLE,
         control,
         rules: {
             required: `${visningsnavn} er påkrevd.`,

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/MottakerFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/MottakerFelt.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ChangeEvent } from 'react';
 import { Select } from '@navikt/ds-react';
 import { useController, useFormContext } from 'react-hook-form';
 import { IPersonopplysninger } from '../../../../../../../App/typer/personopplysninger';
@@ -59,18 +59,19 @@ export function MottakerFelt({ personopplysninger, brevmottakere, erLesevisning 
         }
     }
 
+    function onChange(event: ChangeEvent<HTMLSelectElement>) {
+        const value = event.target.value;
+        const nyMottakerRolle = value as BrevmottakerFormValues[BrevmottakerFeltnavn.MOTTAKERROLLE];
+        oppdatertNavnForMottakerRolleHvisNødvendig(nyMottakerRolle);
+        field.onChange(nyMottakerRolle);
+    }
+
     return (
         <Select
             label={label}
             value={field.value}
             onBlur={field.onBlur}
-            onChange={(event) => {
-                const value = event.target.value;
-                const nyMottakerRolle =
-                    value as BrevmottakerFormValues[BrevmottakerFeltnavn.MOTTAKERROLLE];
-                oppdatertNavnForMottakerRolleHvisNødvendig(nyMottakerRolle);
-                field.onChange(nyMottakerRolle);
-            }}
+            onChange={onChange}
             error={fieldState.error?.message}
             readOnly={erLesevisning || formState.isSubmitting}
         >

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/MottakerFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/MottakerFelt.tsx
@@ -60,8 +60,6 @@ export function MottakerFelt({ personopplysninger, brevmottakere, erLesevisning 
         }
     }
 
-    const visFeilmelding = fieldState.isTouched || formState.isSubmitted;
-
     return (
         <Select
             label={visningsnavn}
@@ -73,7 +71,7 @@ export function MottakerFelt({ personopplysninger, brevmottakere, erLesevisning 
                 oppdatertNavnForMottakerRolleHvisNødvendig(nyMottakerRolle);
                 field.onChange(nyMottakerRolle);
             }}
-            error={visFeilmelding && fieldState.error?.message}
+            error={fieldState.error?.message}
             readOnly={erLesevisning || formState.isSubmitting}
         >
             <option value={''}>-- Velg mottaker --</option>

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/MottakerFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/MottakerFelt.tsx
@@ -22,7 +22,7 @@ interface Props {
     erLesevisning?: boolean;
 }
 
-const visningsnavn = 'Mottaker';
+const label = 'Mottaker';
 
 export function MottakerFelt({ personopplysninger, brevmottakere, erLesevisning = false }: Props) {
     const { control, setValue, getValues } = useFormContext<BrevmottakerFormValues>();
@@ -31,7 +31,7 @@ export function MottakerFelt({ personopplysninger, brevmottakere, erLesevisning 
         name: BrevmottakerFeltnavn.MOTTAKERROLLE,
         control,
         rules: {
-            required: `${visningsnavn} er påkrevd.`,
+            required: `${label} er påkrevd.`,
             deps: [BrevmottakerFeltnavn.LANDKODE],
         },
     });
@@ -61,7 +61,7 @@ export function MottakerFelt({ personopplysninger, brevmottakere, erLesevisning 
 
     return (
         <Select
-            label={visningsnavn}
+            label={label}
             value={field.value}
             onBlur={field.onBlur}
             onChange={(event) => {

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/NavnFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/NavnFelt.tsx
@@ -1,7 +1,7 @@
 import { useController, useFormContext } from 'react-hook-form';
 import React from 'react';
 import { TextField } from '@navikt/ds-react';
-import { MottakerRolle } from '../../../../mottakerRolle';
+import { skalPreutfylleNavnForMottakerRolle } from '../../../../mottakerRolle';
 import { BrevmottakerFeltnavn, BrevmottakerFormValues } from '../BrevmottakerForm';
 
 interface Props {
@@ -25,11 +25,9 @@ export function NavnFelt({ erLesevisning = false }: Props) {
         },
     });
 
-    const mottakerRolle = watch(BrevmottakerFeltnavn.MOTTAKERROLLE);
-
-    const navnSkalVærePreutfylt =
-        mottakerRolle === MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE ||
-        mottakerRolle === MottakerRolle.DØDSBO;
+    const navnSkalVærePreutfylt = skalPreutfylleNavnForMottakerRolle(
+        watch(BrevmottakerFeltnavn.MOTTAKERROLLE)
+    );
 
     return (
         <TextField

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/NavnFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/NavnFelt.tsx
@@ -1,4 +1,4 @@
-import { Controller, useFormContext } from 'react-hook-form';
+import { useController, useFormContext } from 'react-hook-form';
 import React from 'react';
 import { TextField } from '@navikt/ds-react';
 import { IPersonopplysninger } from '../../../../../../../App/typer/personopplysninger';
@@ -10,36 +10,36 @@ type Props = BrevmottakerFeltProps & {
 };
 
 export function NavnFelt({ feltnavn, visningsnavn, erLesevisning }: Props) {
-    const { control, formState, watch } = useFormContext();
+    const { control, watch } = useFormContext();
+
+    const { field, fieldState, formState } = useController({
+        name: feltnavn,
+        control,
+        rules: {
+            required: 'Navn på person eller organisasjon er påkrevd.',
+            maxLength: {
+                value: 80,
+                message: 'Navn på personen eller organisasjon kan ikke inneholde mer enn 80 tegn.',
+            },
+        },
+    });
+
+    const visFeilmelding = fieldState.isTouched || formState.isSubmitted;
+
+    const mottakerRolle = watch(BrevmottakerFeltnavn.MOTTAKERROLLE);
+
+    const navnSkalVærePreutfylt =
+        mottakerRolle === MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE ||
+        mottakerRolle === MottakerRolle.DØDSBO;
+
     return (
-        <Controller
-            control={control}
-            name={feltnavn}
-            rules={{
-                required: 'Navn på person eller organisasjon er påkrevd.',
-                maxLength: {
-                    value: 80,
-                    message:
-                        'Navn på personen eller organisasjon kan ikke inneholde mer enn 80 tegn.',
-                },
-            }}
-            render={({ field, fieldState }) => {
-                const visFeilmelding = fieldState.isTouched || formState.isSubmitted;
-                const mottakerRolle = watch(BrevmottakerFeltnavn.MOTTAKERROLLE);
-                const navnSkalVærePreutfylt =
-                    mottakerRolle === MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE ||
-                    mottakerRolle === MottakerRolle.DØDSBO;
-                return (
-                    <TextField
-                        label={visningsnavn}
-                        value={field.value}
-                        onBlur={field.onBlur}
-                        onChange={field.onChange}
-                        error={visFeilmelding && fieldState.error?.message}
-                        readOnly={erLesevisning || navnSkalVærePreutfylt || formState.isSubmitting}
-                    />
-                );
-            }}
+        <TextField
+            label={visningsnavn}
+            value={field.value}
+            onBlur={field.onBlur}
+            onChange={field.onChange}
+            error={visFeilmelding && fieldState.error?.message}
+            readOnly={erLesevisning || navnSkalVærePreutfylt || formState.isSubmitting}
         />
     );
 }

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/NavnFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/NavnFelt.tsx
@@ -1,9 +1,8 @@
 import { useController, useFormContext } from 'react-hook-form';
 import React from 'react';
 import { TextField } from '@navikt/ds-react';
-import { BrevmottakerFeltnavn } from './felttyper';
 import { MottakerRolle } from '../../../../mottakerRolle';
-import { BrevmottakerFormValues } from '../BrevmottakerForm';
+import { BrevmottakerFeltnavn, BrevmottakerFormValues } from '../BrevmottakerForm';
 
 interface Props {
     erLesevisning?: boolean;

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/NavnFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/NavnFelt.tsx
@@ -1,22 +1,21 @@
 import { useController, useFormContext } from 'react-hook-form';
 import React from 'react';
 import { TextField } from '@navikt/ds-react';
-import { IPersonopplysninger } from '../../../../../../../App/typer/personopplysninger';
-import { BrevmottakerFeltnavn, BrevmottakerFeltProps } from './felttyper';
+import { BrevmottakerFeltnavn } from './felttyper';
 import { MottakerRolle } from '../../../../mottakerRolle';
 import { BrevmottakerFormValues } from '../BrevmottakerForm';
 
-type Props = BrevmottakerFeltProps & {
-    personopplysninger: IPersonopplysninger;
-};
+interface Props {
+    erLesevisning?: boolean;
+}
 
 const visningsnavn = 'Navn';
 
-export function NavnFelt({ feltnavn, erLesevisning }: Props) {
+export function NavnFelt({ erLesevisning = false }: Props) {
     const { control, watch } = useFormContext<BrevmottakerFormValues>();
 
     const { field, fieldState, formState } = useController({
-        name: feltnavn,
+        name: BrevmottakerFeltnavn.NAVN,
         control,
         rules: {
             required: `${visningsnavn} på person eller organisasjon er påkrevd.`,

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/NavnFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/NavnFelt.tsx
@@ -9,17 +9,19 @@ type Props = BrevmottakerFeltProps & {
     personopplysninger: IPersonopplysninger;
 };
 
-export function NavnFelt({ feltnavn, visningsnavn, erLesevisning }: Props) {
+const visningsnavn = 'Navn';
+
+export function NavnFelt({ feltnavn, erLesevisning }: Props) {
     const { control, watch } = useFormContext();
 
     const { field, fieldState, formState } = useController({
         name: feltnavn,
         control,
         rules: {
-            required: 'Navn på person eller organisasjon er påkrevd.',
+            required: `${visningsnavn} på person eller organisasjon er påkrevd.`,
             maxLength: {
                 value: 80,
-                message: 'Navn på personen eller organisasjon kan ikke inneholde mer enn 80 tegn.',
+                message: `${visningsnavn} på personen eller organisasjon kan ikke inneholde mer enn 80 tegn.`,
             },
         },
     });

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/NavnFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/NavnFelt.tsx
@@ -25,8 +25,6 @@ export function NavnFelt({ erLesevisning = false }: Props) {
         },
     });
 
-    const visFeilmelding = fieldState.isTouched || formState.isSubmitted;
-
     const mottakerRolle = watch(BrevmottakerFeltnavn.MOTTAKERROLLE);
 
     const navnSkalVærePreutfylt =
@@ -39,7 +37,7 @@ export function NavnFelt({ erLesevisning = false }: Props) {
             value={field.value}
             onBlur={field.onBlur}
             onChange={field.onChange}
-            error={visFeilmelding && fieldState.error?.message}
+            error={fieldState.error?.message}
             readOnly={erLesevisning || navnSkalVærePreutfylt || formState.isSubmitting}
         />
     );

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/NavnFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/NavnFelt.tsx
@@ -4,6 +4,7 @@ import { TextField } from '@navikt/ds-react';
 import { IPersonopplysninger } from '../../../../../../../App/typer/personopplysninger';
 import { BrevmottakerFeltnavn, BrevmottakerFeltProps } from './felttyper';
 import { MottakerRolle } from '../../../../mottakerRolle';
+import { BrevmottakerFormValues } from '../BrevmottakerForm';
 
 type Props = BrevmottakerFeltProps & {
     personopplysninger: IPersonopplysninger;
@@ -12,7 +13,7 @@ type Props = BrevmottakerFeltProps & {
 const visningsnavn = 'Navn';
 
 export function NavnFelt({ feltnavn, erLesevisning }: Props) {
-    const { control, watch } = useFormContext();
+    const { control, watch } = useFormContext<BrevmottakerFormValues>();
 
     const { field, fieldState, formState } = useController({
         name: feltnavn,

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/NavnFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/NavnFelt.tsx
@@ -8,7 +8,7 @@ interface Props {
     erLesevisning?: boolean;
 }
 
-const visningsnavn = 'Navn';
+const label = 'Navn';
 
 export function NavnFelt({ erLesevisning = false }: Props) {
     const { control, watch } = useFormContext<BrevmottakerFormValues>();
@@ -17,10 +17,10 @@ export function NavnFelt({ erLesevisning = false }: Props) {
         name: BrevmottakerFeltnavn.NAVN,
         control,
         rules: {
-            required: `${visningsnavn} på person eller organisasjon er påkrevd.`,
+            required: `${label} på person eller organisasjon er påkrevd.`,
             maxLength: {
                 value: 80,
-                message: `${visningsnavn} på personen eller organisasjon kan ikke inneholde mer enn 80 tegn.`,
+                message: `${label} på personen eller organisasjon kan ikke inneholde mer enn 80 tegn.`,
             },
         },
     });
@@ -31,7 +31,7 @@ export function NavnFelt({ erLesevisning = false }: Props) {
 
     return (
         <TextField
-            label={visningsnavn}
+            label={label}
             value={field.value}
             onBlur={field.onBlur}
             onChange={field.onChange}

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/PostnummerFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/PostnummerFelt.tsx
@@ -2,18 +2,20 @@ import { useController, useFormContext } from 'react-hook-form';
 import React from 'react';
 import { TextField } from '@navikt/ds-react';
 import { EøsLandkode } from '../../../../../../../Felles/Landvelger/landkode';
-import { BrevmottakerFeltnavn, BrevmottakerFeltProps } from './felttyper';
+import { BrevmottakerFeltnavn } from './felttyper';
 import { BrevmottakerFormValues } from '../BrevmottakerForm';
 
-type Props = BrevmottakerFeltProps;
+interface Props {
+    erLesevisning?: boolean;
+}
 
 const visningsnavn = 'Postnummer';
 
-export function PostnummerFelt({ feltnavn, erLesevisning }: Props) {
+export function PostnummerFelt({ erLesevisning = false }: Props) {
     const { control, getValues } = useFormContext<BrevmottakerFormValues>();
 
     const { field, fieldState, formState } = useController({
-        name: feltnavn,
+        name: BrevmottakerFeltnavn.POSTNUMMER,
         control,
         rules: {
             required:

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/PostnummerFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/PostnummerFelt.tsx
@@ -1,4 +1,4 @@
-import { Controller, useFormContext } from 'react-hook-form';
+import { useController, useFormContext } from 'react-hook-form';
 import React from 'react';
 import { TextField } from '@navikt/ds-react';
 import { EøsLandkode } from '../../../../../../../Felles/Landvelger/landkode';
@@ -7,35 +7,34 @@ import { BrevmottakerFeltnavn, BrevmottakerFeltProps } from './felttyper';
 type Props = BrevmottakerFeltProps;
 
 export function PostnummerFelt({ feltnavn, visningsnavn, erLesevisning }: Props) {
-    const { control, getValues, formState } = useFormContext();
+    const { control, getValues } = useFormContext();
+
+    const { field, fieldState, formState } = useController({
+        name: feltnavn,
+        control,
+        rules: {
+            required:
+                getValues(BrevmottakerFeltnavn.LANDKODE) === EøsLandkode.NO
+                    ? `${visningsnavn} er påkrevd om landet er Norge.`
+                    : undefined,
+            maxLength: { value: 4, message: `${visningsnavn} må inneholde 4 tegn.` },
+            minLength: { value: 4, message: `${visningsnavn} må inneholde 4 tegn.` },
+        },
+    });
+
+    const visFeilmelding = fieldState.isTouched || formState.isSubmitted;
+
     return (
-        <Controller
-            control={control}
-            name={feltnavn}
-            rules={{
-                required:
-                    getValues(BrevmottakerFeltnavn.LANDKODE) === EøsLandkode.NO
-                        ? `${visningsnavn} er påkrevd om landet er Norge.`
-                        : undefined,
-                maxLength: { value: 4, message: `${visningsnavn} må inneholde 4 tegn.` },
-                minLength: { value: 4, message: `${visningsnavn} må inneholde 4 tegn.` },
-            }}
-            render={({ field, fieldState }) => {
-                const visFeilmelding = fieldState.isTouched || formState.isSubmitted;
-                return (
-                    <TextField
-                        htmlSize={4}
-                        maxLength={4}
-                        type={'number'}
-                        label={visningsnavn}
-                        value={field.value}
-                        onBlur={field.onBlur}
-                        onChange={field.onChange}
-                        error={visFeilmelding && fieldState.error?.message}
-                        readOnly={erLesevisning || formState.isSubmitting}
-                    />
-                );
-            }}
+        <TextField
+            htmlSize={4}
+            maxLength={4}
+            type={'number'}
+            label={visningsnavn}
+            value={field.value}
+            onBlur={field.onBlur}
+            onChange={field.onChange}
+            error={visFeilmelding && fieldState.error?.message}
+            readOnly={erLesevisning || formState.isSubmitting}
         />
     );
 }

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/PostnummerFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/PostnummerFelt.tsx
@@ -8,7 +8,7 @@ interface Props {
     erLesevisning?: boolean;
 }
 
-const visningsnavn = 'Postnummer';
+const label = 'Postnummer';
 
 export function PostnummerFelt({ erLesevisning = false }: Props) {
     const { control, getValues } = useFormContext<BrevmottakerFormValues>();
@@ -19,10 +19,10 @@ export function PostnummerFelt({ erLesevisning = false }: Props) {
         rules: {
             required:
                 getValues(BrevmottakerFeltnavn.LANDKODE) === EøsLandkode.NO
-                    ? `${visningsnavn} er påkrevd om landet er Norge.`
+                    ? `${label} er påkrevd om landet er Norge.`
                     : undefined,
-            maxLength: { value: 4, message: `${visningsnavn} må inneholde 4 tegn.` },
-            minLength: { value: 4, message: `${visningsnavn} må inneholde 4 tegn.` },
+            maxLength: { value: 4, message: `${label} må inneholde 4 tegn.` },
+            minLength: { value: 4, message: `${label} må inneholde 4 tegn.` },
         },
     });
 
@@ -31,7 +31,7 @@ export function PostnummerFelt({ erLesevisning = false }: Props) {
             htmlSize={4}
             maxLength={4}
             type={'number'}
-            label={visningsnavn}
+            label={label}
             value={field.value}
             onBlur={field.onBlur}
             onChange={field.onChange}

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/PostnummerFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/PostnummerFelt.tsx
@@ -3,13 +3,14 @@ import React from 'react';
 import { TextField } from '@navikt/ds-react';
 import { EøsLandkode } from '../../../../../../../Felles/Landvelger/landkode';
 import { BrevmottakerFeltnavn, BrevmottakerFeltProps } from './felttyper';
+import { BrevmottakerFormValues } from '../BrevmottakerForm';
 
 type Props = BrevmottakerFeltProps;
 
 const visningsnavn = 'Postnummer';
 
 export function PostnummerFelt({ feltnavn, erLesevisning }: Props) {
-    const { control, getValues } = useFormContext();
+    const { control, getValues } = useFormContext<BrevmottakerFormValues>();
 
     const { field, fieldState, formState } = useController({
         name: feltnavn,

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/PostnummerFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/PostnummerFelt.tsx
@@ -2,8 +2,7 @@ import { useController, useFormContext } from 'react-hook-form';
 import React from 'react';
 import { TextField } from '@navikt/ds-react';
 import { EøsLandkode } from '../../../../../../../Felles/Landvelger/landkode';
-import { BrevmottakerFeltnavn } from './felttyper';
-import { BrevmottakerFormValues } from '../BrevmottakerForm';
+import { BrevmottakerFeltnavn, BrevmottakerFormValues } from '../BrevmottakerForm';
 
 interface Props {
     erLesevisning?: boolean;

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/PostnummerFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/PostnummerFelt.tsx
@@ -26,8 +26,6 @@ export function PostnummerFelt({ erLesevisning = false }: Props) {
         },
     });
 
-    const visFeilmelding = fieldState.isTouched || formState.isSubmitted;
-
     return (
         <TextField
             htmlSize={4}
@@ -37,7 +35,7 @@ export function PostnummerFelt({ erLesevisning = false }: Props) {
             value={field.value}
             onBlur={field.onBlur}
             onChange={field.onChange}
-            error={visFeilmelding && fieldState.error?.message}
+            error={fieldState.error?.message}
             readOnly={erLesevisning || formState.isSubmitting}
         />
     );

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/PostnummerFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/PostnummerFelt.tsx
@@ -6,7 +6,9 @@ import { BrevmottakerFeltnavn, BrevmottakerFeltProps } from './felttyper';
 
 type Props = BrevmottakerFeltProps;
 
-export function PostnummerFelt({ feltnavn, visningsnavn, erLesevisning }: Props) {
+const visningsnavn = 'Postnummer';
+
+export function PostnummerFelt({ feltnavn, erLesevisning }: Props) {
     const { control, getValues } = useFormContext();
 
     const { field, fieldState, formState } = useController({

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/PoststedFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/PoststedFelt.tsx
@@ -6,7 +6,9 @@ import { BrevmottakerFeltnavn, BrevmottakerFeltProps } from './felttyper';
 
 type Props = BrevmottakerFeltProps;
 
-export function PoststedFelt({ feltnavn, visningsnavn, erLesevisning }: Props) {
+const visningsnavn = 'Poststed';
+
+export function PoststedFelt({ feltnavn, erLesevisning }: Props) {
     const { control, getValues } = useFormContext();
 
     const { field, fieldState, formState } = useController({

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/PoststedFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/PoststedFelt.tsx
@@ -8,7 +8,7 @@ interface Props {
     erLesevisning?: boolean;
 }
 
-const visningsnavn = 'Poststed';
+const label = 'Poststed';
 
 export function PoststedFelt({ erLesevisning = false }: Props) {
     const { control, getValues } = useFormContext<BrevmottakerFormValues>();
@@ -19,15 +19,15 @@ export function PoststedFelt({ erLesevisning = false }: Props) {
         rules: {
             required:
                 getValues(BrevmottakerFeltnavn.LANDKODE) === EøsLandkode.NO
-                    ? `${visningsnavn} er påkrevd om landet er Norge.`
+                    ? `${label} er påkrevd om landet er Norge.`
                     : undefined,
-            maxLength: { value: 50, message: `${visningsnavn} kan inneholde maks 50 tegn.` },
+            maxLength: { value: 50, message: `${label} kan inneholde maks 50 tegn.` },
         },
     });
 
     return (
         <TextField
-            label={visningsnavn}
+            label={label}
             value={field.value}
             onBlur={field.onBlur}
             onChange={field.onChange}

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/PoststedFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/PoststedFelt.tsx
@@ -25,15 +25,13 @@ export function PoststedFelt({ erLesevisning = false }: Props) {
         },
     });
 
-    const visFeilmelding = fieldState.isTouched || formState.isSubmitted;
-
     return (
         <TextField
             label={visningsnavn}
             value={field.value}
             onBlur={field.onBlur}
             onChange={field.onChange}
-            error={visFeilmelding && fieldState.error?.message}
+            error={fieldState.error?.message}
             readOnly={erLesevisning || formState.isSubmitting}
         />
     );

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/PoststedFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/PoststedFelt.tsx
@@ -2,18 +2,20 @@ import { useController, useFormContext } from 'react-hook-form';
 import React from 'react';
 import { TextField } from '@navikt/ds-react';
 import { EøsLandkode } from '../../../../../../../Felles/Landvelger/landkode';
-import { BrevmottakerFeltnavn, BrevmottakerFeltProps } from './felttyper';
+import { BrevmottakerFeltnavn } from './felttyper';
 import { BrevmottakerFormValues } from '../BrevmottakerForm';
 
-type Props = BrevmottakerFeltProps;
+interface Props {
+    erLesevisning?: boolean;
+}
 
 const visningsnavn = 'Poststed';
 
-export function PoststedFelt({ feltnavn, erLesevisning }: Props) {
+export function PoststedFelt({ erLesevisning = false }: Props) {
     const { control, getValues } = useFormContext<BrevmottakerFormValues>();
 
     const { field, fieldState, formState } = useController({
-        name: feltnavn,
+        name: BrevmottakerFeltnavn.POSTSTED,
         control,
         rules: {
             required:

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/PoststedFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/PoststedFelt.tsx
@@ -2,8 +2,7 @@ import { useController, useFormContext } from 'react-hook-form';
 import React from 'react';
 import { TextField } from '@navikt/ds-react';
 import { EøsLandkode } from '../../../../../../../Felles/Landvelger/landkode';
-import { BrevmottakerFeltnavn } from './felttyper';
-import { BrevmottakerFormValues } from '../BrevmottakerForm';
+import { BrevmottakerFeltnavn, BrevmottakerFormValues } from '../BrevmottakerForm';
 
 interface Props {
     erLesevisning?: boolean;

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/PoststedFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/PoststedFelt.tsx
@@ -3,13 +3,14 @@ import React from 'react';
 import { TextField } from '@navikt/ds-react';
 import { EøsLandkode } from '../../../../../../../Felles/Landvelger/landkode';
 import { BrevmottakerFeltnavn, BrevmottakerFeltProps } from './felttyper';
+import { BrevmottakerFormValues } from '../BrevmottakerForm';
 
 type Props = BrevmottakerFeltProps;
 
 const visningsnavn = 'Poststed';
 
 export function PoststedFelt({ feltnavn, erLesevisning }: Props) {
-    const { control, getValues } = useFormContext();
+    const { control, getValues } = useFormContext<BrevmottakerFormValues>();
 
     const { field, fieldState, formState } = useController({
         name: feltnavn,

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/PoststedFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/PoststedFelt.tsx
@@ -1,4 +1,4 @@
-import { Controller, useFormContext } from 'react-hook-form';
+import { useController, useFormContext } from 'react-hook-form';
 import React from 'react';
 import { TextField } from '@navikt/ds-react';
 import { EøsLandkode } from '../../../../../../../Felles/Landvelger/landkode';
@@ -7,31 +7,30 @@ import { BrevmottakerFeltnavn, BrevmottakerFeltProps } from './felttyper';
 type Props = BrevmottakerFeltProps;
 
 export function PoststedFelt({ feltnavn, visningsnavn, erLesevisning }: Props) {
-    const { control, getValues, formState } = useFormContext();
+    const { control, getValues } = useFormContext();
+
+    const { field, fieldState, formState } = useController({
+        name: feltnavn,
+        control,
+        rules: {
+            required:
+                getValues(BrevmottakerFeltnavn.LANDKODE) === EøsLandkode.NO
+                    ? `${visningsnavn} er påkrevd om landet er Norge.`
+                    : undefined,
+            maxLength: { value: 50, message: `${visningsnavn} kan inneholde maks 50 tegn.` },
+        },
+    });
+
+    const visFeilmelding = fieldState.isTouched || formState.isSubmitted;
+
     return (
-        <Controller
-            control={control}
-            name={feltnavn}
-            rules={{
-                required:
-                    getValues(BrevmottakerFeltnavn.LANDKODE) === EøsLandkode.NO
-                        ? `${visningsnavn} er påkrevd om landet er Norge.`
-                        : undefined,
-                maxLength: { value: 50, message: `${visningsnavn} kan inneholde maks 50 tegn.` },
-            }}
-            render={({ field, fieldState }) => {
-                const visFeilmelding = fieldState.isTouched || formState.isSubmitted;
-                return (
-                    <TextField
-                        label={visningsnavn}
-                        value={field.value}
-                        onBlur={field.onBlur}
-                        onChange={field.onChange}
-                        error={visFeilmelding && fieldState.error?.message}
-                        readOnly={erLesevisning || formState.isSubmitting}
-                    />
-                );
-            }}
+        <TextField
+            label={visningsnavn}
+            value={field.value}
+            onBlur={field.onBlur}
+            onChange={field.onChange}
+            error={visFeilmelding && fieldState.error?.message}
+            readOnly={erLesevisning || formState.isSubmitting}
         />
     );
 }

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/felttyper.ts
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/felttyper.ts
@@ -1,8 +1,3 @@
-export type BrevmottakerFeltProps = {
-    feltnavn: BrevmottakerFeltnavn;
-    erLesevisning?: boolean;
-};
-
 export enum BrevmottakerFeltnavn {
     MOTTAKERROLLE = 'mottakerRolle',
     LANDKODE = 'landkode',

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/felttyper.ts
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/felttyper.ts
@@ -1,6 +1,5 @@
 export type BrevmottakerFeltProps = {
     feltnavn: BrevmottakerFeltnavn;
-    visningsnavn: string;
     erLesevisning?: boolean;
 };
 

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/felttyper.ts
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/felttyper.ts
@@ -1,9 +1,0 @@
-export enum BrevmottakerFeltnavn {
-    MOTTAKERROLLE = 'mottakerRolle',
-    LANDKODE = 'landkode',
-    NAVN = 'navn',
-    ADRESSELINJE1 = 'adresselinje1',
-    ADRESSELINJE2 = 'adresselinje2',
-    POSTNUMMER = 'postnummer',
-    POSTSTED = 'poststed',
-}

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/brevmottaker.ts
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/brevmottaker.ts
@@ -1,6 +1,6 @@
 import { MottakerRolle } from './mottakerRolle';
 import { IFullmakt, IVergemål } from '../../../App/typer/personopplysninger';
-import { EøsLandkode } from '../../../Felles/Landvelger/landkode';
+import { BlankEøsLandkode, erEøsLandkode, EøsLandkode } from '../../../Felles/Landvelger/landkode';
 
 export type Brevmottaker = object;
 
@@ -62,15 +62,16 @@ export function erBrevmottakerPersonUtenIdent(
 
 export function utledBrevmottakerPersonUtenIdentNavnVedDødsbo(
     navn: string,
-    landkode: EøsLandkode | string
+    landkode: EøsLandkode | BlankEøsLandkode
 ): string {
-    const erEøsLandkode = Object.values(EøsLandkode).includes(landkode as EøsLandkode);
-    return landkode === EøsLandkode.NO || !erEøsLandkode ? `${navn} v/dødsbo` : `Estate of ${navn}`;
+    return landkode === EøsLandkode.NO || !erEøsLandkode(landkode)
+        ? `${navn} v/dødsbo`
+        : `Estate of ${navn}`;
 }
 
 export function utledPreutfyltBrevmottakerPersonUtenIdentNavn(
     navnFraPersonopplysninger: string,
-    landkode: EøsLandkode | string,
+    landkode: EøsLandkode | BlankEøsLandkode,
     mottakerRolle: MottakerRolle
 ): string {
     switch (mottakerRolle) {

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/brevmottaker.ts
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/brevmottaker.ts
@@ -62,15 +62,16 @@ export function erBrevmottakerPersonUtenIdent(
 
 export function utledBrevmottakerPersonUtenIdentNavnVedDødsbo(
     navn: string,
-    landkode: string
+    landkode: EøsLandkode | string
 ): string {
-    return landkode === EøsLandkode.NO ? `${navn} v/dødsbo` : `Estate of ${navn}`;
+    const erEøsLandkode = Object.values(EøsLandkode).includes(landkode as EøsLandkode);
+    return landkode === EøsLandkode.NO || !erEøsLandkode ? `${navn} v/dødsbo` : `Estate of ${navn}`;
 }
 
 export function utledPreutfyltBrevmottakerPersonUtenIdentNavn(
     navnFraPersonopplysninger: string,
-    landkode: string,
-    mottakerRolle: MottakerRolle | string
+    landkode: EøsLandkode | string,
+    mottakerRolle: MottakerRolle
 ): string {
     switch (mottakerRolle) {
         case MottakerRolle.DØDSBO:

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/mottakerRolle.ts
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/mottakerRolle.ts
@@ -25,7 +25,7 @@ export function skalNavnVærePreutfyltForMottakerRolle(mottakerRolle: MottakerRo
 
 export function erGyldigMottakerRolleForLandkode(
     mottakerRolle: MottakerRolle,
-    landkode: EøsLandkode | ''
+    landkode: EøsLandkode
 ): boolean {
     const landkodeErNO = landkode === EøsLandkode.NO;
     const erBrukerMedUtenlandskAdresse =

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/mottakerRolle.ts
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/mottakerRolle.ts
@@ -1,4 +1,6 @@
-import { EøsLandkode } from '../../../Felles/Landvelger/landkode';
+import { BlankEøsLandkode, erEøsLandkode, EøsLandkode } from '../../../Felles/Landvelger/landkode';
+import { utledPreutfyltBrevmottakerPersonUtenIdentNavn } from './brevmottaker';
+import { IPersonopplysninger } from '../../../App/typer/personopplysninger';
 
 export type BlankMottakerRolle = '';
 
@@ -18,11 +20,14 @@ export const mottakerRolleVisningsnavn: Record<MottakerRolle, string> = {
     DØDSBO: 'Dødsbo',
 };
 
+export function erMottakerRolle(verdi: string): verdi is MottakerRolle {
+    return Object.values(MottakerRolle).includes(verdi as MottakerRolle);
+}
+
 export function skalPreutfylleNavnForMottakerRolle(
     mottakerRolle: MottakerRolle | BlankMottakerRolle
 ) {
-    const erMottakerRolle = Object.values(MottakerRolle).includes(mottakerRolle as MottakerRolle);
-    if (!erMottakerRolle) {
+    if (!erMottakerRolle(mottakerRolle)) {
         return false;
     }
     return (
@@ -39,4 +44,25 @@ export function erGyldigMottakerRolleForLandkode(
     const erBrukerMedUtenlandskAdresse =
         mottakerRolle === MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE;
     return !(landkodeErNO && erBrukerMedUtenlandskAdresse);
+}
+
+export function finnNyttBrevmottakernavnHvisNødvendigVedEndringAvMottakerRolle(
+    nyMottakerRolle: MottakerRolle,
+    forrigeMottakerRolle: MottakerRolle | BlankMottakerRolle,
+    landkode: EøsLandkode | BlankEøsLandkode,
+    personopplysninger: IPersonopplysninger
+): string | undefined {
+    const skalNavnPreutfylles = skalPreutfylleNavnForMottakerRolle(nyMottakerRolle);
+    if (skalNavnPreutfylles) {
+        return utledPreutfyltBrevmottakerPersonUtenIdentNavn(
+            personopplysninger.navn,
+            erEøsLandkode(landkode) ? landkode : EøsLandkode.NO,
+            nyMottakerRolle
+        );
+    }
+    const varNavnPreutfylt = skalPreutfylleNavnForMottakerRolle(forrigeMottakerRolle);
+    if (varNavnPreutfylt) {
+        return '';
+    }
+    return undefined;
 }

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/mottakerRolle.ts
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/mottakerRolle.ts
@@ -1,5 +1,7 @@
 import { EøsLandkode } from '../../../Felles/Landvelger/landkode';
 
+export type BlankMottakerRolle = '';
+
 export enum MottakerRolle {
     BRUKER = 'BRUKER',
     VERGE = 'VERGE',
@@ -16,10 +18,16 @@ export const mottakerRolleVisningsnavn: Record<MottakerRolle, string> = {
     DØDSBO: 'Dødsbo',
 };
 
-export function skalNavnVærePreutfyltForMottakerRolle(mottakerRolle: MottakerRolle): boolean {
+export function skalPreutfylleNavnForMottakerRolle(
+    mottakerRolle: MottakerRolle | BlankMottakerRolle
+) {
+    const erMottakerRolle = Object.values(MottakerRolle).includes(mottakerRolle as MottakerRolle);
+    if (!erMottakerRolle) {
+        return false;
+    }
     return (
-        mottakerRolle === MottakerRolle.DØDSBO ||
-        mottakerRolle === MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE
+        mottakerRolle === MottakerRolle.BRUKER_MED_UTENLANDSK_ADRESSE ||
+        mottakerRolle === MottakerRolle.DØDSBO
     );
 }
 

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/nyBrevmottaker.test.ts
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/nyBrevmottaker.test.ts
@@ -1,9 +1,8 @@
 import { describe, expect } from 'vitest';
 import { lagNyBrevmottakerPersonUtenIdent, NyBrevmottakerType } from './nyBrevmottaker';
-import { BrevmottakerFeltnavn } from './baks/modal/form/felt/felttyper';
 import { MottakerRolle } from './mottakerRolle';
 import { EøsLandkode } from '../../../Felles/Landvelger/landkode';
-import { BrevmottakerFormValues } from './baks/modal/form/BrevmottakerForm';
+import { BrevmottakerFeltnavn, BrevmottakerFormValues } from './baks/modal/form/BrevmottakerForm';
 
 describe('NyBrevmottakerTest', () => {
     describe('LagNyBrevmottakerPersonUtenIdentTest', () => {


### PR DESCRIPTION
Favro: [NAV-25011](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25011)

Refaktorer eksisterende brevmottaker form/felter litt da det skal gjenbrukes en del logikk i "henlegg behandling" modalen.

Har kjørt opp løsningen og ser ut til å fungere bra. 

Det enkleste er kanskje bare å sjekke ut branchen selv å gå gjennom kode der, ble en litt uoversiktlig PR. 