### PR TITLE
Setter vurdering endret når man oppdaterer tekst i internnotat

### DIFF
--- a/src/frontend/Komponenter/Behandling/Vurdering/InterntNotat.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/InterntNotat.tsx
@@ -20,13 +20,25 @@ const KnappWrapper = styled.div`
 
 export const InterntNotat: React.FC<{
     behandlingErRedigerbar: boolean;
+    vurderingEndret: boolean;
+    settVurderingEndret: (value: React.SetStateAction<boolean>) => void;
     tekst?: string;
     settIkkePersistertKomponent: (verdi: string) => void;
     settOppdatertVurdering: (vurdering: React.SetStateAction<IVurdering>) => void;
-}> = ({ behandlingErRedigerbar, tekst, settIkkePersistertKomponent, settOppdatertVurdering }) => {
+}> = ({
+    behandlingErRedigerbar,
+    vurderingEndret,
+    settVurderingEndret,
+    tekst,
+    settIkkePersistertKomponent,
+    settOppdatertVurdering,
+}) => {
     const [skalViseFritekstFelt, settSkalViseFritekstFelt] = useState<boolean>(harVerdi(tekst));
 
     const oppdaterTekst = (tekst?: string) => {
+        if (!vurderingEndret) {
+            settVurderingEndret(true);
+        }
         settOppdatertVurdering((prevState) => ({
             ...prevState,
             interntNotat: tekst,

--- a/src/frontend/Komponenter/Behandling/Vurdering/VurderingRedigeringsmodus.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/VurderingRedigeringsmodus.tsx
@@ -187,6 +187,8 @@ export const VurderingRedigeringsmodus = ({
                     />
                     <InterntNotat
                         behandlingErRedigerbar={behandlingErRedigerbar}
+                        vurderingEndret={vurderingEndret}
+                        settVurderingEndret={settVurderingEndret}
                         tekst={oppdatertVurdering?.interntNotat}
                         settIkkePersistertKomponent={settIkkePersistertKomponent}
                         settOppdatertVurdering={settOppdatertVurdering}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? :sparkles:

Setter vurdering endret når man oppdaterer tekst i internnotat, så man får lagret om det er den eneste endringen man gjør.


[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-25242)