### PR TITLE
Flyttet sjekk for klagebehandling avsluttet før sjekk for behandlingfeilregistert

### DIFF
--- a/src/frontend/Komponenter/Behandling/Resultat/utils.ts
+++ b/src/frontend/Komponenter/Behandling/Resultat/utils.ts
@@ -29,14 +29,6 @@ export const fjernDuplikatStegFraHistorikk = (steg: IBehandlingshistorikk[]) => 
 };
 
 export const utledTekstForEksternutfall = (behandling: Behandling) => {
-    const erFeilregistrert = behandling.klageinstansResultat.some(
-        (resultat) => resultat.type === KlageinstansEventType.BEHANDLING_FEILREGISTRERT
-    );
-
-    if (erFeilregistrert) {
-        return 'Behandling feilregistrert';
-    }
-
     const klageResultatMedUtfall = behandling.klageinstansResultat.filter(
         (resultat) =>
             resultat.utfall && resultat.type == KlageinstansEventType.KLAGEBEHANDLING_AVSLUTTET
@@ -46,6 +38,14 @@ export const utledTekstForEksternutfall = (behandling: Behandling) => {
         if (utfall.utfall) {
             return utfallTilTekst[utfall.utfall];
         }
+    }
+
+    const erFeilregistrert = behandling.klageinstansResultat.some(
+        (resultat) => resultat.type === KlageinstansEventType.BEHANDLING_FEILREGISTRERT
+    );
+
+    if (erFeilregistrert) {
+        return 'Behandling feilregistrert';
     }
 };
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? :sparkles:

Oppstått tilfelle hvor det er registrert klageresultat KLAGEBEHANDLING_AVSLUTTET og BEHANDLING_FEILREGISTRERT i samme klage behandling. Som koden var før ville resultatet behandling feilregistrert ta prioritet over behandling avsluttet som fører til forvirring. Flytter dermed sjekken for feilregistrert etter avsluttet.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-25326)