### PR TITLE
NAV-25011: Setter "henlegg" knappen til å være inaktiv når man åpner brevmottaker-skjemaet

### DIFF
--- a/src/frontend/Komponenter/Behandling/Henleggelse/HenleggBehandlingModalInnhold.tsx
+++ b/src/frontend/Komponenter/Behandling/Henleggelse/HenleggBehandlingModalInnhold.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Alert, Box, Button, HStack, Modal, Skeleton, VStack } from '@navikt/ds-react';
+import { Alert, Box, Button, Heading, HStack, Modal, Skeleton, VStack } from '@navikt/ds-react';
 import { IPersonopplysninger } from '../../../App/typer/personopplysninger';
 import styled from 'styled-components';
 import {
@@ -131,13 +131,24 @@ export function HenleggBehandlingModalInnhold({ behandling, personopplysninger }
                             <>
                                 <Divider />
                                 <Box as={'div'} width={'45%'}>
-                                    <BrevmottakerForm
-                                        form={brevmottakerForm}
-                                        onSubmit={submitBrevmottakerForm}
-                                        onCancel={skjulBrevmottakerForm}
-                                        personopplysninger={personopplysninger}
-                                        valgteMottakerRoller={mapTilMottakerRolle(brevmottakere)}
-                                    />
+                                    <VStack gap={'4'}>
+                                        <Heading level={'2'} size={'small'}>
+                                            Ny brevmottaker
+                                        </Heading>
+                                        <Alert variant={'info'}>
+                                            Legg til en brevmottaker eller lukk skjemaet for å
+                                            henlegge behandlingen.
+                                        </Alert>
+                                        <BrevmottakerForm
+                                            form={brevmottakerForm}
+                                            onSubmit={submitBrevmottakerForm}
+                                            onCancel={skjulBrevmottakerForm}
+                                            personopplysninger={personopplysninger}
+                                            valgteMottakerRoller={mapTilMottakerRolle(
+                                                brevmottakere
+                                            )}
+                                        />
+                                    </VStack>
                                 </Box>
                             </>
                         )}
@@ -162,7 +173,9 @@ export function HenleggBehandlingModalInnhold({ behandling, personopplysninger }
                     form={HENLEGG_BEHANDLING_FORM_ID}
                     variant={'primary'}
                     type={'submit'}
-                    disabled={henleggBehandlingForm.formState.isSubmitting}
+                    disabled={
+                        henleggBehandlingForm.formState.isSubmitting || erBrevmottakerFormSynlig
+                    }
                     loading={henleggBehandlingForm.formState.isSubmitting}
                 >
                     Henlegg


### PR DESCRIPTION
Favro: [NAV-25011](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25011)

Gjør "henlegg" knappen inaktiv når man har åpnet brevmottaker-skjemaet for å forhindre noen å fylle ut skjemaet for å så trykke "henlegg" før de trykker "legg til brevmottaker". La til en melding over skjemaet som forklarer hvorfor "henlegg" knappen er inaktiv. 

Når brevmottaker-skjemaet er åpent:
<img width="1074" alt="image" src="https://github.com/user-attachments/assets/8efb7716-3dc9-43af-b8cc-5784053a2df5" />

Når brevmottaker-skjemaet er lukket:
<img width="646" alt="image" src="https://github.com/user-attachments/assets/faee12ff-1cbb-49c6-9441-87ae6011c3d5" />
