### PR TITLE
add tslib

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "styled-components": "^6.1.19",
     "svg-inline-loader": "^0.8.2",
     "ts-node": "^10.9.2",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "tslib": "^2.8.1"
   },
   "devDependencies": {
     "@babel/core": "^7.27.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8309,7 +8309,7 @@ tslib@2.6.2:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
-tslib@^2.0.3:
+tslib@^2.0.3, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==


### PR DESCRIPTION
Får følgende feilmelding ved deploy. Ser ut som "familie-backend" trenger tslib. Ser andre prosjekter har lagt det til i deres `package.json` fil. 

```
  |   | 2025-06-27 10:26:45.270 | Error: Cannot find package 'tslib' imported from /app/node_modules/@navikt/familie-backend/dist/index.js
```

`"importHelpers": true `er allerede satt [her](https://github.com/navikt/familie-klage-frontend/blob/main/tsconfig.base.json#L9)

