### PR TITLE
Legg til manglende enhet i header

### DIFF
--- a/src/frontend/Felles/HeaderMedSøk/HeaderMedSøk.tsx
+++ b/src/frontend/Felles/HeaderMedSøk/HeaderMedSøk.tsx
@@ -82,6 +82,7 @@ export const HeaderMedSøk: React.FunctionComponent<IProps> = ({ innloggetSaksbe
                 tittel="NAV Familie - klage"
                 brukerinfo={{
                     navn: innloggetSaksbehandler?.displayName || 'Ukjent',
+                    enhet: innloggetSaksbehandler?.enhet,
                 }}
                 brukerPopoverItems={[{ name: 'Logg ut', href: `${window.origin}/auth/logout` }]}
                 eksterneLenker={eksterneLenker}


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25659

Man sendte ikke med enhet når man oppretter Header komponenten som førte til at det sto Ukjent Enhet.

Før:
<img width="208" alt="førFik" src="https://github.com/user-attachments/assets/3cebc77d-0c89-4720-8323-0a7aff356b09" />

Etter:
<img width="220" alt="etterFik" src="https://github.com/user-attachments/assets/fcf98a7a-3b1c-4bde-b409-28c8721a60de" />
