### PR TITLE
NAV-26390: Rydder opp og fikser noen bugs i brevmottaker skjema

### DIFF
--- a/src/frontend/Felles/Landvelger/EøsLandvelger.tsx
+++ b/src/frontend/Felles/Landvelger/EøsLandvelger.tsx
@@ -6,13 +6,22 @@ import { ComboboxOption } from '@navikt/ds-react/cjs/form/combobox/types';
 import { EøsLandkode } from './landkode';
 
 type Props = {
+    ref?: React.Ref<HTMLInputElement>;
     label: React.ReactNode;
-} & Omit<ComboboxProps, 'options'>;
+    onSelect: (landkode: EøsLandkode) => void;
+} & Omit<
+    ComboboxProps,
+    | 'isMultiSelect'
+    | 'shouldAutocomplete'
+    | 'options'
+    | 'selectedOptions'
+    | 'onToggleSelected'
+    | 'onSelect'
+>;
 
-const DEFAULT_COMBOBOX_OPTION: ComboboxOption = { value: '', label: '-- Velg land --' };
+const FALLBACK_COMBOBOX_OPTION: ComboboxOption = { value: '', label: '-- Velg land --' };
 
 const eøsLand: ComboboxOption[] = [
-    DEFAULT_COMBOBOX_OPTION,
     { value: EøsLandkode.BE, label: 'Belgia' },
     { value: EøsLandkode.BG, label: 'Bulgaria' },
     { value: EøsLandkode.DK, label: 'Danmark' },
@@ -44,34 +53,28 @@ const eøsLand: ComboboxOption[] = [
     { value: EøsLandkode.DE, label: 'Tyskland' },
     { value: EøsLandkode.HU, label: 'Ungarn' },
     { value: EøsLandkode.AT, label: 'Østerrike' },
-];
+].sort((l1, l2) => l1.value.localeCompare(l2.value));
 
-export function EøsLandvelger(props: Props) {
-    const { label, value, onToggleSelected, error, onBlur, readOnly } = props;
+export function EøsLandvelger({ value, onSelect, ...rest }: Props) {
     const [selectedOption, setSelectedOption] = useState<ComboboxOption | undefined>(
         eøsLand.find((opt) => opt.value === value)
     );
     return (
         <UNSAFE_Combobox
-            label={label}
-            options={eøsLand}
-            onBlur={onBlur}
+            {...rest}
             isMultiSelect={false}
-            selectedOptions={selectedOption ? [selectedOption] : []}
-            onToggleSelected={(option, isSelected) => {
-                const newOption = eøsLand.find((opt) => opt.value === option);
-                if (newOption === selectedOption || newOption == undefined) {
-                    setSelectedOption(DEFAULT_COMBOBOX_OPTION);
-                } else {
-                    setSelectedOption(newOption);
-                }
-                if (onToggleSelected) {
-                    onToggleSelected(option, isSelected, false);
-                }
-            }}
-            error={error}
             shouldAutocomplete={true}
-            readOnly={readOnly}
+            options={eøsLand}
+            selectedOptions={selectedOption ? [selectedOption] : []}
+            onToggleSelected={(option) => {
+                const newOption = eøsLand.find((opt) => opt.value === option);
+                if (newOption == undefined) {
+                    setSelectedOption(FALLBACK_COMBOBOX_OPTION);
+                    return;
+                }
+                setSelectedOption(newOption);
+                onSelect(newOption.value as EøsLandkode);
+            }}
         />
     );
 }

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/BrevmottakerModalBody.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/BrevmottakerModalBody.tsx
@@ -4,10 +4,9 @@ import { PlusCircleIcon } from '@navikt/aksel-icons';
 import { Alert, Button, Heading, Modal, VStack } from '@navikt/ds-react';
 
 import {
+    BrevmottakerFeltnavn,
     BrevmottakerForm,
     BrevmottakerFormValues,
-    CustomFormErrors,
-    useBrevmottakerForm,
 } from './form/BrevmottakerForm';
 import { IPersonopplysninger } from '../../../../../App/typer/personopplysninger';
 import { BrevmottakerDetaljer } from './BrevmottakerDetaljer';
@@ -18,6 +17,8 @@ import {
 } from '../../brevmottaker';
 import { lagNyBrevmottakerPersonUtenIdent, NyBrevmottaker } from '../../nyBrevmottaker';
 import { SlettbarBrevmottaker } from '../../slettbarBrevmottaker';
+import { useForm } from 'react-hook-form';
+import { EøsLandkode } from '../../../../../Felles/Landvelger/landkode';
 
 type Props = {
     personopplysninger: IPersonopplysninger;
@@ -32,7 +33,17 @@ export function BrevmottakerModalBody({
     opprettBrevmottaker,
     slettBrevmottaker,
 }: Props) {
-    const form = useBrevmottakerForm();
+    const form = useForm<BrevmottakerFormValues>({
+        defaultValues: {
+            [BrevmottakerFeltnavn.MOTTAKERROLLE]: '',
+            [BrevmottakerFeltnavn.LANDKODE]: EøsLandkode.NO,
+            [BrevmottakerFeltnavn.NAVN]: '',
+            [BrevmottakerFeltnavn.ADRESSELINJE1]: '',
+            [BrevmottakerFeltnavn.ADRESSELINJE2]: '',
+            [BrevmottakerFeltnavn.POSTNUMMER]: '',
+            [BrevmottakerFeltnavn.POSTSTED]: '',
+        },
+    });
 
     const [visForm, settVisForm] = useState(brevmottakere.length === 0);
 
@@ -41,9 +52,7 @@ export function BrevmottakerModalBody({
     ): Promise<Awaited<void>> {
         return opprettBrevmottaker(lagNyBrevmottakerPersonUtenIdent(brevmottakerFormValues))
             .then(() => settVisForm(false))
-            .catch((error: Error) =>
-                form.setError(CustomFormErrors.onSubmitServerError.id, { message: error.message })
-            );
+            .catch((error: Error) => form.setError('root', { message: error.message }));
     }
 
     async function slettBrevmottakerOgVisFormHvisNødvendig(

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/BrevmottakerForm.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/BrevmottakerForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FieldErrors, FormProvider, SubmitHandler, useForm, UseFormReturn } from 'react-hook-form';
+import { FormProvider, SubmitHandler, UseFormReturn } from 'react-hook-form';
 import { LandFelt } from './felt/LandFelt';
 import { MottakerFelt } from './felt/MottakerFelt';
 import { NavnFelt } from './felt/NavnFelt';
@@ -15,19 +15,6 @@ import { useBehandling } from '../../../../../../App/context/BehandlingContext';
 import { useOnUnmount } from '../../../../../../App/hooks/useOnUnmount';
 import { useOnFormSubmitSuccessful } from '../../../../../../App/hooks/useOnFormSubmitSuccessful';
 import { useConfirmBrowserRefresh } from '../../../../../../App/hooks/useConfirmBrowserRefresh';
-
-export const CustomFormErrors: Record<
-    'onSubmitServerError',
-    {
-        id: `root.${string}`;
-        lookup: (errors: FieldErrors<BrevmottakerFormValues>) => string | undefined;
-    }
-> = {
-    onSubmitServerError: {
-        id: 'root.onSubmitServerError',
-        lookup: (errors) => errors?.root?.onSubmitServerError?.message,
-    },
-};
 
 export enum BrevmottakerFeltnavn {
     MOTTAKERROLLE = 'mottakerRolle',
@@ -47,21 +34,6 @@ export interface BrevmottakerFormValues {
     [BrevmottakerFeltnavn.ADRESSELINJE2]: string;
     [BrevmottakerFeltnavn.POSTNUMMER]: string;
     [BrevmottakerFeltnavn.POSTSTED]: string;
-}
-
-export function useBrevmottakerForm() {
-    return useForm<BrevmottakerFormValues>({
-        shouldUnregister: true,
-        defaultValues: {
-            [BrevmottakerFeltnavn.MOTTAKERROLLE]: '',
-            [BrevmottakerFeltnavn.LANDKODE]: EøsLandkode.NO,
-            [BrevmottakerFeltnavn.NAVN]: '',
-            [BrevmottakerFeltnavn.ADRESSELINJE1]: '',
-            [BrevmottakerFeltnavn.ADRESSELINJE2]: '',
-            [BrevmottakerFeltnavn.POSTNUMMER]: '',
-            [BrevmottakerFeltnavn.POSTSTED]: '',
-        },
-    });
 }
 
 interface Props {
@@ -97,7 +69,6 @@ export function BrevmottakerForm({
     useConfirmBrowserRefresh({ enabled: isDirty });
 
     const landkode = watch(BrevmottakerFeltnavn.LANDKODE);
-    const onSubmitServerError = CustomFormErrors.onSubmitServerError.lookup(errors);
 
     return (
         <FormProvider {...form}>
@@ -123,13 +94,9 @@ export function BrevmottakerForm({
                             </>
                         )}
                     </Fieldset>
-                    {onSubmitServerError && (
-                        <Alert
-                            variant={'error'}
-                            closeButton={true}
-                            onClose={() => clearErrors(CustomFormErrors.onSubmitServerError.id)}
-                        >
-                            {onSubmitServerError}
+                    {errors.root?.message && (
+                        <Alert variant={'error'} closeButton={true} onClose={() => clearErrors()}>
+                            {errors.root.message}
                         </Alert>
                     )}
                     <HStack gap={'4'}>

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/LandFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/LandFelt.tsx
@@ -5,7 +5,7 @@ import { IPersonopplysninger } from '../../../../../../../App/typer/personopplys
 import { erGyldigMottakerRolleForLandkode, MottakerRolle } from '../../../../mottakerRolle';
 import { utledBrevmottakerPersonUtenIdentNavnVedDødsbo } from '../../../../brevmottaker';
 import { BrevmottakerFeltnavn, BrevmottakerFormValues } from '../BrevmottakerForm';
-import { erEøsLandkode } from '../../../../../../../Felles/Landvelger/landkode';
+import { EøsLandkode } from '../../../../../../../Felles/Landvelger/landkode';
 
 interface Props {
     personopplysninger: IPersonopplysninger;
@@ -15,7 +15,7 @@ interface Props {
 const label = 'Land';
 
 export function LandFelt({ personopplysninger, erLesevisning = false }: Props) {
-    const { control, getValues, setValue } = useFormContext<BrevmottakerFormValues>();
+    const { control, getValues, setValue, resetField } = useFormContext<BrevmottakerFormValues>();
 
     const { field, fieldState, formState } = useController({
         name: BrevmottakerFeltnavn.LANDKODE,
@@ -37,28 +37,30 @@ export function LandFelt({ personopplysninger, erLesevisning = false }: Props) {
         },
     });
 
-    function onToggleSelected(value: string, isSelected: boolean) {
-        if (!isSelected || !erEøsLandkode(value)) {
-            field.onChange('');
-            return;
+    function onSelect(landkode: EøsLandkode) {
+        if (landkode !== EøsLandkode.NO) {
+            resetField(BrevmottakerFeltnavn.POSTNUMMER);
+            resetField(BrevmottakerFeltnavn.POSTSTED);
         }
         const mottakerRolle = getValues(BrevmottakerFeltnavn.MOTTAKERROLLE);
         if (mottakerRolle === MottakerRolle.DØDSBO) {
             const nyttPreutfyltNavn = utledBrevmottakerPersonUtenIdentNavnVedDødsbo(
                 personopplysninger.navn,
-                value
+                landkode
             );
             setValue(BrevmottakerFeltnavn.NAVN, nyttPreutfyltNavn);
         }
-        field.onChange(value);
+        field.onChange(landkode);
     }
 
     return (
         <EøsLandvelger
             label={label}
+            name={field.name}
+            ref={field.ref}
             onBlur={field.onBlur}
             value={field.value}
-            onToggleSelected={onToggleSelected}
+            onSelect={onSelect}
             error={fieldState.error?.message}
             readOnly={erLesevisning || formState.isSubmitting}
         />

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/mottakerRolle.ts
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/mottakerRolle.ts
@@ -97,5 +97,6 @@ export function utledGyldigeMottakerRollerBasertPåAlleredeValgteMottakerRoller(
 
     return Object.values(MottakerRolle)
         .filter((mottakerRolle) => mottakerRolle !== MottakerRolle.BRUKER)
+        .filter((mottakerRolle) => mottakerRolle !== MottakerRolle.MOTTAKER)
         .filter((mottakerRolle) => !relevanteValgteMottakerRoller.includes(mottakerRolle));
 }

--- a/src/frontend/Komponenter/Behandling/Henleggelse/hooks/useBrevmottakerForm.ts
+++ b/src/frontend/Komponenter/Behandling/Henleggelse/hooks/useBrevmottakerForm.ts
@@ -19,7 +19,6 @@ export function useBrevmottakerForm() {
     const [erFormSynlig, settErFormSynlig] = useState<boolean>(false);
 
     const form = useForm<BrevmottakerFormValues>({
-        shouldUnregister: true,
         defaultValues: {
             [BrevmottakerFeltnavn.MOTTAKERROLLE]: '',
             [BrevmottakerFeltnavn.LANDKODE]: EøsLandkode.NO,


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-26390

Oppdaget at det var oppstått flere bugs i brevmottaker skjema når man legger til brevmottakere enten på brev fanen eller når man henlegger en behandling. Gjør også noen opprydninger.

- Går over til `error.root` fra en custom `onSubmitServerError` error type. 
- Fjerner "-- Velg land --" fra landvelger da den alltid skal være preutfylt med "Norge" og land er alltid påkrevd.
- Landvelger kan ikke lengre "unselecte" et valg. Hvis man velger det samme landet blir det bare værende som valgt.
- Tilbakestiller felter manuelt i stedet for å bruke  `shouldUnregister`. `shouldUnregister` ga rare feil. 
- Filtrer bort den nye mottaker rollen `MOTTAKER`. 