### PR TITLE
Legg til støtte for skjermet barn

### DIFF
--- a/src/frontend/App/context/AppContext.tsx
+++ b/src/frontend/App/context/AppContext.tsx
@@ -27,7 +27,8 @@ const [AppProvider, useApp] = constate(({ autentisertSaksbehandler, appEnv }: IP
     const [byttUrl, settByttUrl] = useState(false);
     const [toast, settToast] = useState<EToast | undefined>();
     const [valgtFagsakId, settValgtFagsakId] = useState<string>();
-    const [personIdent, settPersonIdent] = useState<string>();
+    const [fagsakEierPersonIdent, settFagsakEierPersonIdent] = useState<string>();
+    const [søkerPersonIdent, settSøkerPersonIdent] = useState<string>();
     const [visBrevmottakereModal, settVisBrevmottakereModal] = useState(false);
 
     useEffect(
@@ -105,8 +106,10 @@ const [AppProvider, useApp] = constate(({ autentisertSaksbehandler, appEnv }: IP
         settValgtFagsakId,
         visBrevmottakereModal,
         settVisBrevmottakereModal,
-        personIdent,
-        settPersonIdent,
+        fagsakEierPersonIdent,
+        settFagsakEierPersonIdent,
+        søkerPersonIdent,
+        settSøkerPersonIdent,
     };
 });
 

--- a/src/frontend/App/context/BehandlingContext.tsx
+++ b/src/frontend/App/context/BehandlingContext.tsx
@@ -38,7 +38,7 @@ const [BehandlingProvider, useBehandling] = constate(() => {
         behandlingId,
     ]);
 
-    useEffect(() => hentPersonopplysninger(behandlingId), [behandlingId, hentPersonopplysninger]);
+    useEffect(() => hentPersonopplysninger(), [hentPersonopplysninger]);
 
     useEffect(() => {
         if (behandling.status === RessursStatus.SUKSESS) {

--- a/src/frontend/App/context/PersonopplysningerContext.tsx
+++ b/src/frontend/App/context/PersonopplysningerContext.tsx
@@ -1,10 +1,12 @@
 import React, { createContext, PropsWithChildren, useContext } from 'react';
-import { IPersonopplysninger } from '../typer/personopplysninger';
+import { IPersonopplysningerFagsakeierOgSøker } from '../typer/personopplysninger';
 import { useSetPersonIdent } from '../hooks/useSetPersonIdent';
 
-const PersonopplysningerContext = createContext<IPersonopplysninger | undefined>(undefined);
+const PersonopplysningerContext = createContext<IPersonopplysningerFagsakeierOgSøker | undefined>(
+    undefined
+);
 
-export const usePersonopplysningerContext = (): IPersonopplysninger => {
+export const usePersonopplysningerContext = (): IPersonopplysningerFagsakeierOgSøker => {
     const context = useContext(PersonopplysningerContext);
     if (context === undefined) {
         throw new Error(
@@ -15,11 +17,11 @@ export const usePersonopplysningerContext = (): IPersonopplysninger => {
 };
 
 interface Props extends PropsWithChildren {
-    personopplysninger: IPersonopplysninger;
+    personopplysninger: IPersonopplysningerFagsakeierOgSøker;
 }
 
 export function PersonopplysningerContextProvider({ personopplysninger, children }: Props) {
-    useSetPersonIdent(personopplysninger.personIdent);
+    useSetPersonIdent(personopplysninger.fagsakEier.personIdent);
 
     return (
         <PersonopplysningerContext.Provider value={personopplysninger}>

--- a/src/frontend/App/context/PersonopplysningerContext.tsx
+++ b/src/frontend/App/context/PersonopplysningerContext.tsx
@@ -21,7 +21,7 @@ interface Props extends PropsWithChildren {
 }
 
 export function PersonopplysningerContextProvider({ personopplysninger, children }: Props) {
-    useSetPersonIdent(personopplysninger.fagsakEier.personIdent);
+    useSetPersonIdent(personopplysninger);
 
     return (
         <PersonopplysningerContext.Provider value={personopplysninger}>

--- a/src/frontend/App/context/toggles.ts
+++ b/src/frontend/App/context/toggles.ts
@@ -4,4 +4,5 @@ export interface Toggles {
 
 export enum ToggleName {
     MANUELL_BREVMOTTAKER_ORGANISASJON = 'familie-klage.manuell-brevmottaker-organisasjon',
+    BRUK_SØKER_PERSONOPPLYSNINGER = 'familie-klage.bruk-soker-personopplysninger',
 }

--- a/src/frontend/App/hooks/useHentPersonopplysninger.ts
+++ b/src/frontend/App/hooks/useHentPersonopplysninger.ts
@@ -1,23 +1,23 @@
 import { byggHenterRessurs, byggTomRessurs, Ressurs } from '../typer/ressurs';
 import { useApp } from '../context/AppContext';
 import { useCallback, useState } from 'react';
-import { IPersonopplysninger } from '../typer/personopplysninger';
+import { IPersonopplysningerFagsakeierOgSøker } from '../typer/personopplysninger';
 
 export const useHentPersonopplysninger = (
     behandlingId: string
 ): {
-    hentPersonopplysninger: (behandlingsid: string) => void;
-    personopplysningerResponse: Ressurs<IPersonopplysninger>;
+    hentPersonopplysninger: () => void;
+    personopplysningerResponse: Ressurs<IPersonopplysningerFagsakeierOgSøker>;
 } => {
     const { axiosRequest } = useApp();
     const [personopplysningerResponse, settPersonopplysningerResponse] =
-        useState<Ressurs<IPersonopplysninger>>(byggTomRessurs());
+        useState<Ressurs<IPersonopplysningerFagsakeierOgSøker>>(byggTomRessurs());
 
     const hentPersonopplysninger = useCallback(() => {
         settPersonopplysningerResponse(byggHenterRessurs());
-        axiosRequest<IPersonopplysninger, { behandlingId: string }>({
+        axiosRequest<IPersonopplysningerFagsakeierOgSøker, void>({
             method: 'GET',
-            url: `/familie-klage/api/personopplysninger/${behandlingId}`,
+            url: `/familie-klage/api/personopplysninger/${behandlingId}/fagsak-eier-og-soker`,
         }).then((res) => {
             settPersonopplysningerResponse(res);
         });

--- a/src/frontend/App/hooks/useSetPersonIdent.ts
+++ b/src/frontend/App/hooks/useSetPersonIdent.ts
@@ -1,13 +1,19 @@
 import { useApp } from '../context/AppContext';
 import { useEffect } from 'react';
+import { IPersonopplysningerFagsakeierOgSøker } from '../typer/personopplysninger';
 
-export const useSetPersonIdent = (personIdent: string) => {
-    const { settPersonIdent } = useApp();
+export const useSetPersonIdent = (personopplysninger: IPersonopplysningerFagsakeierOgSøker) => {
+    const { settFagsakEierPersonIdent, settSøkerPersonIdent } = useApp();
 
     useEffect(() => {
-        settPersonIdent(personIdent);
-        return () => settPersonIdent(undefined);
-    }, [settPersonIdent, personIdent]);
+        settFagsakEierPersonIdent(personopplysninger.fagsakEier.personIdent);
+        return () => settFagsakEierPersonIdent(undefined);
+    }, [settFagsakEierPersonIdent, personopplysninger.fagsakEier.personIdent]);
+
+    useEffect(() => {
+        settSøkerPersonIdent(personopplysninger.søker.personIdent);
+        return () => settSøkerPersonIdent(undefined);
+    }, [settSøkerPersonIdent, personopplysninger.søker.personIdent]);
 
     return {};
 };

--- a/src/frontend/App/typer/personopplysninger.ts
+++ b/src/frontend/App/typer/personopplysninger.ts
@@ -1,5 +1,10 @@
 import { erEtterDagensDato } from '../utils/dato';
 
+export interface IPersonopplysningerFagsakeierOgSøker {
+    fagsakEier: IPersonopplysninger;
+    søker: IPersonopplysninger;
+}
+
 export interface IPersonopplysninger {
     personIdent: string;
     navn: string;

--- a/src/frontend/App/utils/utils.ts
+++ b/src/frontend/App/utils/utils.ts
@@ -1,5 +1,6 @@
-import { Behandling, Fagsystem } from '../typer/fagsak';
+import { Behandling, Fagsystem, PåklagetVedtakstype } from '../typer/fagsak';
 import { Eksternlenker } from '../typer/eksternlenker';
+import { FagsystemType } from '../../Komponenter/Behandling/Formkrav/typer';
 
 export const base64toBlob = (b64Data: string, contentType = '', sliceSize = 512): Blob => {
     const byteCharacters = atob(b64Data);
@@ -27,12 +28,18 @@ export const harVerdi = (str: string | undefined | null): boolean =>
 export const utledBehandlingLenke = (
     behandling: Behandling,
     eksternLenker: Eksternlenker
-): string => {
-    return utledEksternBehandlingLenke(
-        behandling,
-        behandling.påklagetVedtak?.eksternFagsystemBehandlingId,
-        eksternLenker
-    );
+): string | null => {
+    if (
+        behandling.påklagetVedtak.påklagetVedtakstype === PåklagetVedtakstype.VEDTAK &&
+        behandling.påklagetVedtak.fagsystemVedtak?.fagsystemType === FagsystemType.ORDNIÆR
+    ) {
+        return utledEksternBehandlingLenke(
+            behandling,
+            behandling.påklagetVedtak?.eksternFagsystemBehandlingId,
+            eksternLenker
+        );
+    }
+    return null;
 };
 
 export const utledEksternBehandlingLenke = (
@@ -48,10 +55,16 @@ export const utledEksternBehandlingLenke = (
 export const utledTilbakekrevingLenke = (
     behandling: Behandling,
     eksternLenker: Eksternlenker
-): string => {
-    return `${eksternLenker.tilbakekrevingUrl}/${behandling.fagsystem}/fagsak/${
-        behandling.eksternFagsystemFagsakId
-    }/behandling/${behandling.påklagetVedtak?.eksternFagsystemBehandlingId}`;
+): string | null => {
+    if (
+        behandling.påklagetVedtak.påklagetVedtakstype === PåklagetVedtakstype.VEDTAK &&
+        behandling.påklagetVedtak.fagsystemVedtak?.fagsystemType === FagsystemType.TILBAKEKREVING
+    ) {
+        return `${eksternLenker.tilbakekrevingUrl}/${behandling.fagsystem}/fagsak/${
+            behandling.eksternFagsystemFagsakId
+        }/behandling/${behandling.påklagetVedtak?.eksternFagsystemBehandlingId}`;
+    }
+    return null;
 };
 
 export const utledSaksoversiktLenke = (

--- a/src/frontend/Felles/HeaderMedSøk/HeaderMedSøk.tsx
+++ b/src/frontend/Felles/HeaderMedSøk/HeaderMedSøk.tsx
@@ -11,14 +11,14 @@ import { MenuGridIcon } from '@navikt/aksel-icons';
 export const HeaderMedSøk: React.FunctionComponent<{ innloggetSaksbehandler: ISaksbehandler }> = ({
     innloggetSaksbehandler,
 }) => {
-    const { axiosRequest, appEnv, valgtFagsakId, personIdent } = useApp();
+    const { axiosRequest, appEnv, valgtFagsakId, fagsakEierPersonIdent } = useApp();
 
     const navn = innloggetSaksbehandler?.displayName ?? 'Ukjent';
     const enhet = innloggetSaksbehandler?.enhet ?? 'Ukjent';
     const popoverItems = [{ name: 'Logg ut', href: `${window.origin}/auth/logout` }];
     const eksterneLenker = useMemo(
-        () => lagEksterneLenker(axiosRequest, appEnv, valgtFagsakId, personIdent),
-        [axiosRequest, appEnv, valgtFagsakId, personIdent]
+        () => lagEksterneLenker(axiosRequest, appEnv, valgtFagsakId, fagsakEierPersonIdent),
+        [axiosRequest, appEnv, valgtFagsakId, fagsakEierPersonIdent]
     );
 
     return (

--- a/src/frontend/Felles/IkonVelger/IkonVelger.tsx
+++ b/src/frontend/Felles/IkonVelger/IkonVelger.tsx
@@ -11,17 +11,17 @@ import { InstitusjonIkon } from '../Ikoner/InstitusjonIkon';
 export interface Props {
     alder: number;
     kjønn: Kjønn;
-    width: number;
-    height: number;
     institusjon?: Institusjon;
+    width?: number;
+    height?: number;
 }
 
 export const IkonVelger: React.FunctionComponent<Props> = ({
     alder,
     kjønn,
-    width,
-    height,
     institusjon,
+    width = 24,
+    height = 24,
 }) => {
     if (institusjon) {
         return <InstitusjonIkon height={height} width={width} />;

--- a/src/frontend/Felles/IkonVelger/IkonVelger.tsx
+++ b/src/frontend/Felles/IkonVelger/IkonVelger.tsx
@@ -9,16 +9,16 @@ import { Institusjon } from '../../App/typer/institusjon';
 import { InstitusjonIkon } from '../Ikoner/InstitusjonIkon';
 
 export interface Props {
-    alder: number;
     kjønn: Kjønn;
+    alder?: number;
     institusjon?: Institusjon;
     width?: number;
     height?: number;
 }
 
 export const IkonVelger: React.FunctionComponent<Props> = ({
-    alder,
     kjønn,
+    alder,
     institusjon,
     width = 24,
     height = 24,
@@ -28,13 +28,13 @@ export const IkonVelger: React.FunctionComponent<Props> = ({
     }
     switch (kjønn) {
         case Kjønn.KVINNE:
-            if (alder < 18) {
+            if (!!alder && alder < 18) {
                 return <JenteIkon heigth={height} width={width} />;
             } else {
                 return <KvinneIkon heigth={height} width={width} />;
             }
         case Kjønn.MANN:
-            if (alder < 18) {
+            if (!!alder && alder < 18) {
                 return <GuttIkon heigth={height} width={width} />;
             } else {
                 return <MannIkon heigth={height} width={width} />;

--- a/src/frontend/Felles/Visittkort/LenkerOgKnapper.tsx
+++ b/src/frontend/Felles/Visittkort/LenkerOgKnapper.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ExternalLinkIcon } from '@navikt/aksel-icons';
-import { HStack, Link, Stack } from '@navikt/ds-react';
+import { HStack, Link } from '@navikt/ds-react';
 import { useApp } from '../../App/context/AppContext';
 import {
     Behandling,
@@ -30,39 +30,43 @@ export const LenkerOgKnapper = ({ behandling }: Props) => {
     const tilbakekrevingLenke = utledTilbakekrevingLenke(behandling, appEnv.eksternlenker);
 
     return (
-        <HStack align={'center'} justify={'start'} gap={'space-8'} padding={'space-8'}>
-            {behandlingLenke && (
-                <Link href={behandlingLenke} target="_blank">
-                    Gå til behandling
-                    <ExternalLinkIcon aria-label="Gå til behandling" fontSize={'1.375rem'} />
+        <HStack
+            align={'center'}
+            justify={'end'}
+            gap={'space-8 space-12'}
+            style={{ whiteSpace: 'nowrap' }}
+        >
+            <HStack align={'center'} gap={'space-8 space-12'} wrap={false}>
+                {behandlingLenke && (
+                    <Link href={behandlingLenke} target="_blank">
+                        Gå til behandling
+                        <ExternalLinkIcon aria-label="Gå til behandling" fontSize={'1.375rem'} />
+                    </Link>
+                )}
+                {tilbakekrevingLenke && (
+                    <Link href={tilbakekrevingLenke} target="_blank">
+                        Gå til tilbakekreving
+                        <ExternalLinkIcon
+                            aria-label="Gå til tilbakekreving"
+                            fontSize={'1.375rem'}
+                        />
+                    </Link>
+                )}
+                <Link href={saksoversiktLenke} target="_blank">
+                    Gå til saksoversikt
+                    <ExternalLinkIcon aria-label="Gå til saksoversikt" fontSize={'1.375rem'} />
                 </Link>
-            )}
-            {tilbakekrevingLenke && (
-                <Link href={tilbakekrevingLenke} target="_blank">
-                    Gå til tilbakekreving
-                    <ExternalLinkIcon aria-label="Gå til tilbakekreving" fontSize={'1.375rem'} />
-                </Link>
-            )}
-            <Link href={saksoversiktLenke} target="_blank">
-                Gå til saksoversikt
-                <ExternalLinkIcon aria-label="Gå til saksoversikt" fontSize={'1.375rem'} />
-            </Link>
+            </HStack>
             {behandling && (
-                <Stack direction={'row'} gap={'space-8'}>
-                    <HStack justify={'end'} gap={'space-8'}>
-                        <EtikettSuksess>
-                            {stønadstypeTilTekst[behandling.stønadstype]}
-                        </EtikettSuksess>
-                        {behandling.årsak === Klagebehandlingsårsak.HENVENDELSE_FRA_KABAL && (
-                            <EtikettInfo>
-                                {klagebehandlingsårsakTilTekst[behandling.årsak]}
-                            </EtikettInfo>
-                        )}
-                    </HStack>
+                <HStack align={'center'} gap={'space-8 space-12'} wrap={false}>
+                    <EtikettSuksess>{stønadstypeTilTekst[behandling.stønadstype]}</EtikettSuksess>
+                    {behandling.årsak === Klagebehandlingsårsak.HENVENDELSE_FRA_KABAL && (
+                        <EtikettInfo>{klagebehandlingsårsakTilTekst[behandling.årsak]}</EtikettInfo>
+                    )}
                     <SettPåVentKnapp />
                     <EndreBehandlendeEnhetKnapp fagsystem={behandling.fagsystem} />
                     <HenleggKnapp />
-                </Stack>
+                </HStack>
             )}
         </HStack>
     );

--- a/src/frontend/Felles/Visittkort/LenkerOgKnapper.tsx
+++ b/src/frontend/Felles/Visittkort/LenkerOgKnapper.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { ExternalLinkIcon } from '@navikt/aksel-icons';
+import { HStack, Link, Stack } from '@navikt/ds-react';
+import { useApp } from '../../App/context/AppContext';
+import {
+    Behandling,
+    Klagebehandlingsårsak,
+    klagebehandlingsårsakTilTekst,
+    PåklagetVedtakstype,
+} from '../../App/typer/fagsak';
+import {
+    utledBehandlingLenke,
+    utledSaksoversiktLenke,
+    utledTilbakekrevingLenke,
+} from '../../App/utils/utils';
+import { EtikettInfo, EtikettSuksess } from '../Varsel/Etikett';
+import { stønadstypeTilTekst } from '../../App/typer/stønadstype';
+import { SettPåVentKnapp } from './SettPåVentKnapp';
+import { EndreBehandlendeEnhetKnapp } from './EndreBehandlendeEnhetKnapp';
+import { HenleggKnapp } from './HenleggKnapp';
+import { FagsystemType } from '../../Komponenter/Behandling/Formkrav/typer';
+
+interface Props {
+    behandling: Behandling;
+}
+
+export const LenkerOgKnapper = ({ behandling }: Props) => {
+    const { appEnv } = useApp();
+
+    const skalLenkeTilFagsystemBehandling =
+        behandling.påklagetVedtak.påklagetVedtakstype === PåklagetVedtakstype.VEDTAK &&
+        behandling.påklagetVedtak.fagsystemVedtak?.fagsystemType === FagsystemType.ORDNIÆR;
+    const skalLenkeTilTilbakekreving =
+        behandling.påklagetVedtak.påklagetVedtakstype === PåklagetVedtakstype.VEDTAK &&
+        behandling.påklagetVedtak.fagsystemVedtak?.fagsystemType === FagsystemType.TILBAKEKREVING;
+    const behandlingLenke = utledBehandlingLenke(behandling, appEnv.eksternlenker);
+    const saksoversiktLenke = utledSaksoversiktLenke(behandling, appEnv.eksternlenker);
+    const tilbakekrevingLenke = utledTilbakekrevingLenke(behandling, appEnv.eksternlenker);
+
+    return (
+        <HStack align={'center'} justify={'start'} gap={'space-8'} padding={'space-8'}>
+            {skalLenkeTilFagsystemBehandling && (
+                <Link href={behandlingLenke} target="_blank">
+                    Gå til behandling
+                    <ExternalLinkIcon aria-label="Gå til behandling" fontSize={'1.375rem'} />
+                </Link>
+            )}
+            {skalLenkeTilTilbakekreving && (
+                <Link href={tilbakekrevingLenke} target="_blank">
+                    Gå til tilbakekreving
+                    <ExternalLinkIcon aria-label="Gå til tilbakekreving" fontSize={'1.375rem'} />
+                </Link>
+            )}
+            <Link href={saksoversiktLenke} target="_blank">
+                Gå til saksoversikt
+                <ExternalLinkIcon aria-label="Gå til saksoversikt" fontSize={'1.375rem'} />
+            </Link>
+            {behandling && (
+                <Stack direction={'row'} gap={'space-8'}>
+                    <HStack justify={'end'} gap={'space-8'}>
+                        <EtikettSuksess>
+                            {stønadstypeTilTekst[behandling.stønadstype]}
+                        </EtikettSuksess>
+                        {behandling.årsak === Klagebehandlingsårsak.HENVENDELSE_FRA_KABAL && (
+                            <EtikettInfo>
+                                {klagebehandlingsårsakTilTekst[behandling.årsak]}
+                            </EtikettInfo>
+                        )}
+                    </HStack>
+                    <SettPåVentKnapp />
+                    <EndreBehandlendeEnhetKnapp fagsystem={behandling.fagsystem} />
+                    <HenleggKnapp />
+                </Stack>
+            )}
+        </HStack>
+    );
+};

--- a/src/frontend/Felles/Visittkort/LenkerOgKnapper.tsx
+++ b/src/frontend/Felles/Visittkort/LenkerOgKnapper.tsx
@@ -6,7 +6,6 @@ import {
     Behandling,
     Klagebehandlingsårsak,
     klagebehandlingsårsakTilTekst,
-    PåklagetVedtakstype,
 } from '../../App/typer/fagsak';
 import {
     utledBehandlingLenke,
@@ -18,7 +17,6 @@ import { stønadstypeTilTekst } from '../../App/typer/stønadstype';
 import { SettPåVentKnapp } from './SettPåVentKnapp';
 import { EndreBehandlendeEnhetKnapp } from './EndreBehandlendeEnhetKnapp';
 import { HenleggKnapp } from './HenleggKnapp';
-import { FagsystemType } from '../../Komponenter/Behandling/Formkrav/typer';
 
 interface Props {
     behandling: Behandling;
@@ -27,25 +25,19 @@ interface Props {
 export const LenkerOgKnapper = ({ behandling }: Props) => {
     const { appEnv } = useApp();
 
-    const skalLenkeTilFagsystemBehandling =
-        behandling.påklagetVedtak.påklagetVedtakstype === PåklagetVedtakstype.VEDTAK &&
-        behandling.påklagetVedtak.fagsystemVedtak?.fagsystemType === FagsystemType.ORDNIÆR;
-    const skalLenkeTilTilbakekreving =
-        behandling.påklagetVedtak.påklagetVedtakstype === PåklagetVedtakstype.VEDTAK &&
-        behandling.påklagetVedtak.fagsystemVedtak?.fagsystemType === FagsystemType.TILBAKEKREVING;
     const behandlingLenke = utledBehandlingLenke(behandling, appEnv.eksternlenker);
     const saksoversiktLenke = utledSaksoversiktLenke(behandling, appEnv.eksternlenker);
     const tilbakekrevingLenke = utledTilbakekrevingLenke(behandling, appEnv.eksternlenker);
 
     return (
         <HStack align={'center'} justify={'start'} gap={'space-8'} padding={'space-8'}>
-            {skalLenkeTilFagsystemBehandling && (
+            {behandlingLenke && (
                 <Link href={behandlingLenke} target="_blank">
                     Gå til behandling
                     <ExternalLinkIcon aria-label="Gå til behandling" fontSize={'1.375rem'} />
                 </Link>
             )}
-            {skalLenkeTilTilbakekreving && (
+            {tilbakekrevingLenke && (
                 <Link href={tilbakekrevingLenke} target="_blank">
                     Gå til tilbakekreving
                     <ExternalLinkIcon aria-label="Gå til tilbakekreving" fontSize={'1.375rem'} />

--- a/src/frontend/Felles/Visittkort/LenkerOgKnapper.tsx
+++ b/src/frontend/Felles/Visittkort/LenkerOgKnapper.tsx
@@ -38,13 +38,13 @@ export const LenkerOgKnapper = ({ behandling }: Props) => {
         >
             <HStack align={'center'} gap={'space-8 space-12'} wrap={false}>
                 {behandlingLenke && (
-                    <Link href={behandlingLenke} target="_blank">
+                    <Link href={behandlingLenke} target="_blank" rel="noopener noreferrer">
                         Gå til behandling
                         <ExternalLinkIcon aria-label="Gå til behandling" fontSize={'1.375rem'} />
                     </Link>
                 )}
                 {tilbakekrevingLenke && (
-                    <Link href={tilbakekrevingLenke} target="_blank">
+                    <Link href={tilbakekrevingLenke} target="_blank" rel="noopener noreferrer">
                         Gå til tilbakekreving
                         <ExternalLinkIcon
                             aria-label="Gå til tilbakekreving"
@@ -52,7 +52,7 @@ export const LenkerOgKnapper = ({ behandling }: Props) => {
                         />
                     </Link>
                 )}
-                <Link href={saksoversiktLenke} target="_blank">
+                <Link href={saksoversiktLenke} target="_blank" rel="noopener noreferrer">
                     Gå til saksoversikt
                     <ExternalLinkIcon aria-label="Gå til saksoversikt" fontSize={'1.375rem'} />
                 </Link>

--- a/src/frontend/Felles/Visittkort/NavnOgIdent.tsx
+++ b/src/frontend/Felles/Visittkort/NavnOgIdent.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { BodyShort, CopyButton, HStack } from '@navikt/ds-react';
+
+export const NavnOgIdent = ({
+    navn,
+    ident,
+    alder,
+}: {
+    navn: string;
+    ident: string;
+    alder?: number;
+}) => {
+    return (
+        <HStack align={'center'} gap={'space-8 space-12'} wrap={false}>
+            <BodyShort as={'span'} weight={'semibold'} style={{ whiteSpace: 'nowrap' }}>
+                {navn}
+                {alder && ` (${alder} år)`}
+            </BodyShort>
+            <div>|</div>
+            <HStack align={'center'} gap={'1'} wrap={false}>
+                {ident}
+                <CopyButton copyText={ident.replaceAll(' ', '')} size={'small'} />
+            </HStack>
+        </HStack>
+    );
+};

--- a/src/frontend/Felles/Visittkort/NavnOgIdent.tsx
+++ b/src/frontend/Felles/Visittkort/NavnOgIdent.tsx
@@ -14,7 +14,7 @@ export const NavnOgIdent = ({
         <HStack align={'center'} gap={'space-8 space-12'} wrap={false}>
             <BodyShort as={'span'} weight={'semibold'} style={{ whiteSpace: 'nowrap' }}>
                 {navn}
-                {alder && ` (${alder} år)`}
+                {alder !== undefined && ` (${alder} år)`}
             </BodyShort>
             <div>|</div>
             <HStack align={'center'} gap={'1'} wrap={false}>

--- a/src/frontend/Felles/Visittkort/PersonopplysningerVarsler.tsx
+++ b/src/frontend/Felles/Visittkort/PersonopplysningerVarsler.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import styles from './Visittkort.module.css';
+import { IPersonopplysninger } from '../../App/typer/personopplysninger';
+import { PersonStatusVarsel } from '../Varsel/PersonStatusVarsel';
+import { AdressebeskyttelseVarsel } from '../Varsel/AdressebeskyttelseVarsel';
+import { EtikettFokus } from '../Varsel/Etikett';
+import { erEtterDagensDato } from '../../App/utils/dato';
+
+export const PersonopplysningerVarsler = ({
+    personopplysninger: {
+        folkeregisterpersonstatus,
+        adressebeskyttelse,
+        egenAnsatt,
+        fullmakt,
+        vergemål,
+    },
+}: {
+    personopplysninger: IPersonopplysninger;
+}) => {
+    return (
+        <>
+            {folkeregisterpersonstatus && (
+                <div className={styles.elementContainer}>
+                    <PersonStatusVarsel folkeregisterpersonstatus={folkeregisterpersonstatus} />
+                </div>
+            )}
+            {adressebeskyttelse && (
+                <div className={styles.elementContainer}>
+                    <AdressebeskyttelseVarsel adressebeskyttelse={adressebeskyttelse} />
+                </div>
+            )}
+            {egenAnsatt && (
+                <div className={styles.elementContainer}>
+                    <EtikettFokus>Egen ansatt</EtikettFokus>
+                </div>
+            )}
+            {fullmakt.some(
+                (f) => f.gyldigTilOgMed === null || erEtterDagensDato(f.gyldigTilOgMed)
+            ) && (
+                <div className={styles.elementContainer}>
+                    <EtikettFokus>Fullmakt</EtikettFokus>
+                </div>
+            )}
+            {vergemål.length > 0 && (
+                <div className={styles.elementContainer}>
+                    <EtikettFokus>Verge</EtikettFokus>
+                </div>
+            )}
+        </>
+    );
+};

--- a/src/frontend/Felles/Visittkort/PersonopplysningerVarsler.tsx
+++ b/src/frontend/Felles/Visittkort/PersonopplysningerVarsler.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import styles from './Visittkort.module.css';
 import { IPersonopplysninger } from '../../App/typer/personopplysninger';
 import { PersonStatusVarsel } from '../Varsel/PersonStatusVarsel';
 import { AdressebeskyttelseVarsel } from '../Varsel/AdressebeskyttelseVarsel';
@@ -20,32 +19,16 @@ export const PersonopplysningerVarsler = ({
     return (
         <>
             {folkeregisterpersonstatus && (
-                <div className={styles.elementContainer}>
-                    <PersonStatusVarsel folkeregisterpersonstatus={folkeregisterpersonstatus} />
-                </div>
+                <PersonStatusVarsel folkeregisterpersonstatus={folkeregisterpersonstatus} />
             )}
             {adressebeskyttelse && (
-                <div className={styles.elementContainer}>
-                    <AdressebeskyttelseVarsel adressebeskyttelse={adressebeskyttelse} />
-                </div>
+                <AdressebeskyttelseVarsel adressebeskyttelse={adressebeskyttelse} />
             )}
-            {egenAnsatt && (
-                <div className={styles.elementContainer}>
-                    <EtikettFokus>Egen ansatt</EtikettFokus>
-                </div>
-            )}
+            {egenAnsatt && <EtikettFokus>Egen ansatt</EtikettFokus>}
             {fullmakt.some(
                 (f) => f.gyldigTilOgMed === null || erEtterDagensDato(f.gyldigTilOgMed)
-            ) && (
-                <div className={styles.elementContainer}>
-                    <EtikettFokus>Fullmakt</EtikettFokus>
-                </div>
-            )}
-            {vergemål.length > 0 && (
-                <div className={styles.elementContainer}>
-                    <EtikettFokus>Verge</EtikettFokus>
-                </div>
-            )}
+            ) && <EtikettFokus>Fullmakt</EtikettFokus>}
+            {vergemål.length > 0 && <EtikettFokus>Verge</EtikettFokus>}
         </>
     );
 };

--- a/src/frontend/Felles/Visittkort/PersonopplysningerVarsler.tsx
+++ b/src/frontend/Felles/Visittkort/PersonopplysningerVarsler.tsx
@@ -4,6 +4,7 @@ import { PersonStatusVarsel } from '../Varsel/PersonStatusVarsel';
 import { AdressebeskyttelseVarsel } from '../Varsel/AdressebeskyttelseVarsel';
 import { EtikettFokus } from '../Varsel/Etikett';
 import { erEtterDagensDato } from '../../App/utils/dato';
+import { HStack } from '@navikt/ds-react';
 
 export const PersonopplysningerVarsler = ({
     personopplysninger: {
@@ -16,19 +17,42 @@ export const PersonopplysningerVarsler = ({
 }: {
     personopplysninger: IPersonopplysninger;
 }) => {
+    const folkregisterpersonstatusVarsel = folkeregisterpersonstatus && (
+        <PersonStatusVarsel folkeregisterpersonstatus={folkeregisterpersonstatus} />
+    );
+
+    const adressebeskyttelseVarsel = adressebeskyttelse && (
+        <AdressebeskyttelseVarsel adressebeskyttelse={adressebeskyttelse} />
+    );
+
+    const egenAnsattVarsel = egenAnsatt && <EtikettFokus>Egen ansatt</EtikettFokus>;
+
+    const fullmaktVarsel = fullmakt.some(
+        (f) => f.gyldigTilOgMed === null || erEtterDagensDato(f.gyldigTilOgMed)
+    ) && <EtikettFokus>Fullmakt</EtikettFokus>;
+
+    const vergemålVarsel = vergemål.length > 0 && <EtikettFokus>Verge</EtikettFokus>;
+
+    if (
+        !folkregisterpersonstatusVarsel &&
+        !adressebeskyttelseVarsel &&
+        !egenAnsattVarsel &&
+        !fullmaktVarsel &&
+        !vergemålVarsel
+    ) {
+        return null;
+    }
+
     return (
         <>
-            {folkeregisterpersonstatus && (
-                <PersonStatusVarsel folkeregisterpersonstatus={folkeregisterpersonstatus} />
-            )}
-            {adressebeskyttelse && (
-                <AdressebeskyttelseVarsel adressebeskyttelse={adressebeskyttelse} />
-            )}
-            {egenAnsatt && <EtikettFokus>Egen ansatt</EtikettFokus>}
-            {fullmakt.some(
-                (f) => f.gyldigTilOgMed === null || erEtterDagensDato(f.gyldigTilOgMed)
-            ) && <EtikettFokus>Fullmakt</EtikettFokus>}
-            {vergemål.length > 0 && <EtikettFokus>Verge</EtikettFokus>}
+            <div>|</div>
+            <HStack align={'center'} gap={'space-8 space-12'} wrap={false}>
+                {folkregisterpersonstatusVarsel}
+                {adressebeskyttelseVarsel}
+                {egenAnsattVarsel}
+                {fullmaktVarsel}
+                {vergemålVarsel}
+            </HStack>
         </>
     );
 };

--- a/src/frontend/Felles/Visittkort/PersonopplysningerVarsler.tsx
+++ b/src/frontend/Felles/Visittkort/PersonopplysningerVarsler.tsx
@@ -17,7 +17,7 @@ export const PersonopplysningerVarsler = ({
 }: {
     personopplysninger: IPersonopplysninger;
 }) => {
-    const folkregisterpersonstatusVarsel = folkeregisterpersonstatus && (
+    const folkeregisterpersonstatusVarsel = folkeregisterpersonstatus && (
         <PersonStatusVarsel folkeregisterpersonstatus={folkeregisterpersonstatus} />
     );
 
@@ -34,7 +34,7 @@ export const PersonopplysningerVarsler = ({
     const vergemålVarsel = vergemål.length > 0 && <EtikettFokus>Verge</EtikettFokus>;
 
     if (
-        !folkregisterpersonstatusVarsel &&
+        !folkeregisterpersonstatusVarsel &&
         !adressebeskyttelseVarsel &&
         !egenAnsattVarsel &&
         !fullmaktVarsel &&
@@ -47,7 +47,7 @@ export const PersonopplysningerVarsler = ({
         <>
             <div>|</div>
             <HStack align={'center'} gap={'space-8 space-12'} wrap={false}>
-                {folkregisterpersonstatusVarsel}
+                {folkeregisterpersonstatusVarsel}
                 {adressebeskyttelseVarsel}
                 {egenAnsattVarsel}
                 {fullmaktVarsel}

--- a/src/frontend/Felles/Visittkort/Visittkort.module.css
+++ b/src/frontend/Felles/Visittkort/Visittkort.module.css
@@ -16,7 +16,3 @@
     overflow: hidden;
     white-space: nowrap;
 }
-
-.elementContainer {
-    margin-left: 1rem;
-}

--- a/src/frontend/Felles/Visittkort/Visittkort.tsx
+++ b/src/frontend/Felles/Visittkort/Visittkort.tsx
@@ -25,8 +25,6 @@ export function Visittkort({ behandling }: Props) {
                         <IkonVelger
                             alder={20}
                             kjønn={fagsakEier.kjønn}
-                            width={24}
-                            height={24}
                             institusjon={behandling.institusjon}
                         />
                         <NavnOgIdent

--- a/src/frontend/Felles/Visittkort/Visittkort.tsx
+++ b/src/frontend/Felles/Visittkort/Visittkort.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import styles from './Visittkort.module.css';
 import { Behandling } from '../../App/typer/fagsak';
-import { BodyShort, CopyButton, HStack, Label } from '@navikt/ds-react';
+import { HStack } from '@navikt/ds-react';
 import { IkonVelger } from '../IkonVelger/IkonVelger';
 import { formaterOrgNummer, Institusjon } from '../../App/typer/institusjon';
 import { usePersonopplysningerContext } from '../../App/context/PersonopplysningerContext';
 import { LenkerOgKnapper } from './LenkerOgKnapper';
 import { PersonopplysningerVarsler } from './PersonopplysningerVarsler';
+import { NavnOgIdent } from './NavnOgIdent';
+import { formaterFødselsnummer } from '../../App/utils/formatter';
 
 interface Props {
     behandling: Behandling;
@@ -22,13 +24,7 @@ export function Visittkort({ behandling }: Props) {
                     alder={20}
                     ident={fagsakEier.personIdent}
                     kjønn={fagsakEier.kjønn}
-                    navn={
-                        <div className={styles.visningsnavn}>
-                            <Label size={'small'} as={'p'}>
-                                {fagsakEier.navn}
-                            </Label>
-                        </div>
-                    }
+                    navn={fagsakEier.navn}
                     institusjon={behandling.institusjon}
                 >
                     <PersonopplysningerVarsler personopplysninger={fagsakEier} />
@@ -43,7 +39,7 @@ export interface IProps extends React.PropsWithChildren {
     alder: number;
     ident: string;
     kjønn: Kjønn;
-    navn: string | React.ReactNode;
+    navn: string;
     institusjon?: Institusjon;
 }
 
@@ -63,31 +59,15 @@ const VisittkortInner: React.FunctionComponent<IProps> = ({
 }) => (
     <HStack align={'center'} gap={'space-8'} padding={'space-8'}>
         <IkonVelger alder={alder} kjønn={kjønn} width={24} height={24} institusjon={institusjon} />
-        {typeof navn === 'string' ? (
-            <Label size={'small'}>
-                {navn} ({alder} år)
-            </Label>
-        ) : (
-            navn
-        )}
-        <div>|</div>
-        <HStack align={'center'} gap={'space-8'} wrap={false}>
-            {ident}
-            <CopyButton copyText={ident.replace(' ', '')} size={'small'} />
-        </HStack>
+        <NavnOgIdent navn={navn} ident={formaterFødselsnummer(ident)} alder={alder} />
         {institusjon && (
-            <HStack align={'center'} gap={'space-8'} wrap={false}>
+            <>
                 <div>|</div>
-                <HStack align={'center'} gap={'1'} wrap={false}>
-                    <BodyShort weight={'semibold'}>Søker:</BodyShort>
-                    {institusjon.navn}
-                </HStack>
-                <div>|</div>
-                <HStack align={'center'} gap={'1'} wrap={false}>
-                    <BodyShort>{formaterOrgNummer(institusjon.orgNummer)} </BodyShort>
-                    <CopyButton copyText={institusjon.orgNummer.replace(' ', '')} size={'small'} />
-                </HStack>
-            </HStack>
+                <NavnOgIdent
+                    navn={`Søker: ${institusjon.navn}`}
+                    ident={formaterOrgNummer(institusjon.orgNummer)}
+                />
+            </>
         )}
         {children}
     </HStack>

--- a/src/frontend/Felles/Visittkort/Visittkort.tsx
+++ b/src/frontend/Felles/Visittkort/Visittkort.tsx
@@ -8,6 +8,7 @@ import { LenkerOgKnapper } from './LenkerOgKnapper';
 import { PersonopplysningerVarsler } from './PersonopplysningerVarsler';
 import { NavnOgIdent } from './NavnOgIdent';
 import { formaterFødselsnummer } from '../../App/utils/formatter';
+import { nullableDatoTilAlder } from '../../App/utils/dato';
 
 interface Props {
     behandling: Behandling;
@@ -23,13 +24,14 @@ export function Visittkort({ behandling }: Props) {
                 <HStack align={'center'} gap={'space-8 space-12'}>
                     <HStack align={'center'} gap={'space-8 space-12'} wrap={false}>
                         <IkonVelger
-                            alder={20}
+                            alder={nullableDatoTilAlder(fagsakEier.fødselsdato) || 18}
                             kjønn={fagsakEier.kjønn}
                             institusjon={behandling.institusjon}
                         />
                         <NavnOgIdent
                             navn={fagsakEier.navn}
                             ident={formaterFødselsnummer(fagsakEier.personIdent)}
+                            alder={nullableDatoTilAlder(fagsakEier.fødselsdato)}
                         />
                     </HStack>
                     <PersonopplysningerVarsler personopplysninger={fagsakEier} />
@@ -39,6 +41,7 @@ export function Visittkort({ behandling }: Props) {
                             <NavnOgIdent
                                 navn={`Søker: ${søker.navn}`}
                                 ident={formaterFødselsnummer(søker.personIdent)}
+                                alder={nullableDatoTilAlder(søker.fødselsdato)}
                             />
                         </>
                     )}

--- a/src/frontend/Felles/Visittkort/Visittkort.tsx
+++ b/src/frontend/Felles/Visittkort/Visittkort.tsx
@@ -15,7 +15,8 @@ interface Props {
 }
 
 export function Visittkort({ behandling }: Props) {
-    const { fagsakEier } = usePersonopplysningerContext();
+    const { fagsakEier, søker } = usePersonopplysningerContext();
+    const skalViseSøker = fagsakEier.personIdent != søker.personIdent;
 
     return (
         <div className={styles.container}>
@@ -33,6 +34,15 @@ export function Visittkort({ behandling }: Props) {
                         ident={formaterFødselsnummer(fagsakEier.personIdent)}
                     />
                     <PersonopplysningerVarsler personopplysninger={fagsakEier} />
+                    {skalViseSøker && (
+                        <>
+                            <div>|</div>
+                            <NavnOgIdent
+                                navn={`Søker: ${søker.navn}`}
+                                ident={formaterFødselsnummer(søker.personIdent)}
+                            />
+                        </>
+                    )}
                     {behandling.institusjon && (
                         <>
                             <div>|</div>

--- a/src/frontend/Felles/Visittkort/Visittkort.tsx
+++ b/src/frontend/Felles/Visittkort/Visittkort.tsx
@@ -2,78 +2,36 @@ import React from 'react';
 import styles from './Visittkort.module.css';
 import { Behandling } from '../../App/typer/fagsak';
 import { BodyShort, CopyButton, HStack, Label } from '@navikt/ds-react';
-import { PersonStatusVarsel } from '../Varsel/PersonStatusVarsel';
-import { AdressebeskyttelseVarsel } from '../Varsel/AdressebeskyttelseVarsel';
-import { EtikettFokus } from '../Varsel/Etikett';
-import { erEtterDagensDato } from '../../App/utils/dato';
 import { IkonVelger } from '../IkonVelger/IkonVelger';
 import { formaterOrgNummer, Institusjon } from '../../App/typer/institusjon';
 import { usePersonopplysningerContext } from '../../App/context/PersonopplysningerContext';
 import { LenkerOgKnapper } from './LenkerOgKnapper';
+import { PersonopplysningerVarsler } from './PersonopplysningerVarsler';
 
 interface Props {
     behandling: Behandling;
 }
 
 export function Visittkort({ behandling }: Props) {
-    const {
-        fagsakEier: {
-            personIdent,
-            kjønn,
-            navn,
-            folkeregisterpersonstatus,
-            adressebeskyttelse,
-            egenAnsatt,
-            fullmakt,
-            vergemål,
-        },
-    } = usePersonopplysningerContext();
+    const { fagsakEier } = usePersonopplysningerContext();
 
     return (
         <div className={styles.container}>
             <HStack justify={'space-between'} width={'100%'}>
                 <VisittkortInner
                     alder={20}
-                    ident={personIdent}
-                    kjønn={kjønn}
+                    ident={fagsakEier.personIdent}
+                    kjønn={fagsakEier.kjønn}
                     navn={
                         <div className={styles.visningsnavn}>
                             <Label size={'small'} as={'p'}>
-                                {navn}
+                                {fagsakEier.navn}
                             </Label>
                         </div>
                     }
                     institusjon={behandling.institusjon}
                 >
-                    {folkeregisterpersonstatus && (
-                        <div className={styles.elementContainer}>
-                            <PersonStatusVarsel
-                                folkeregisterpersonstatus={folkeregisterpersonstatus}
-                            />
-                        </div>
-                    )}
-                    {adressebeskyttelse && (
-                        <div className={styles.elementContainer}>
-                            <AdressebeskyttelseVarsel adressebeskyttelse={adressebeskyttelse} />
-                        </div>
-                    )}
-                    {egenAnsatt && (
-                        <div className={styles.elementContainer}>
-                            <EtikettFokus>Egen ansatt</EtikettFokus>
-                        </div>
-                    )}
-                    {fullmakt.some(
-                        (f) => f.gyldigTilOgMed === null || erEtterDagensDato(f.gyldigTilOgMed)
-                    ) && (
-                        <div className={styles.elementContainer}>
-                            <EtikettFokus>Fullmakt</EtikettFokus>
-                        </div>
-                    )}
-                    {vergemål.length > 0 && (
-                        <div className={styles.elementContainer}>
-                            <EtikettFokus>Verge</EtikettFokus>
-                        </div>
-                    )}
+                    <PersonopplysningerVarsler personopplysninger={fagsakEier} />
                 </VisittkortInner>
                 <LenkerOgKnapper behandling={behandling} />
             </HStack>

--- a/src/frontend/Felles/Visittkort/Visittkort.tsx
+++ b/src/frontend/Felles/Visittkort/Visittkort.tsx
@@ -35,14 +35,16 @@ export function Visittkort({ behandling }: Props) {
     const { appEnv } = useApp();
 
     const {
-        personIdent,
-        kjønn,
-        navn,
-        folkeregisterpersonstatus,
-        adressebeskyttelse,
-        egenAnsatt,
-        fullmakt,
-        vergemål,
+        fagsakEier: {
+            personIdent,
+            kjønn,
+            navn,
+            folkeregisterpersonstatus,
+            adressebeskyttelse,
+            egenAnsatt,
+            fullmakt,
+            vergemål,
+        },
     } = usePersonopplysningerContext();
 
     const skalLenkeTilFagsystemBehandling =

--- a/src/frontend/Felles/Visittkort/Visittkort.tsx
+++ b/src/frontend/Felles/Visittkort/Visittkort.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import styles from './Visittkort.module.css';
 import { Behandling } from '../../App/typer/fagsak';
-import { HStack } from '@navikt/ds-react';
+import { Box, HGrid, HStack } from '@navikt/ds-react';
 import { IkonVelger } from '../IkonVelger/IkonVelger';
 import { formaterOrgNummer } from '../../App/typer/institusjon';
 import { usePersonopplysningerContext } from '../../App/context/PersonopplysningerContext';
@@ -19,20 +18,22 @@ export function Visittkort({ behandling }: Props) {
     const skalViseSøker = fagsakEier.personIdent != søker.personIdent;
 
     return (
-        <div className={styles.container}>
-            <HStack justify={'space-between'} width={'100%'}>
-                <HStack align={'center'} gap={'space-8'} padding={'space-8'}>
-                    <IkonVelger
-                        alder={20}
-                        kjønn={fagsakEier.kjønn}
-                        width={24}
-                        height={24}
-                        institusjon={behandling.institusjon}
-                    />
-                    <NavnOgIdent
-                        navn={fagsakEier.navn}
-                        ident={formaterFødselsnummer(fagsakEier.personIdent)}
-                    />
+        <Box borderWidth={'0 0 1 0'} paddingInline={'4'} paddingBlock={'2'}>
+            <HGrid columns={'auto 1fr'} align={'center'} gap={'4'}>
+                <HStack align={'center'} gap={'space-8 space-12'}>
+                    <HStack align={'center'} gap={'space-8 space-12'} wrap={false}>
+                        <IkonVelger
+                            alder={20}
+                            kjønn={fagsakEier.kjønn}
+                            width={24}
+                            height={24}
+                            institusjon={behandling.institusjon}
+                        />
+                        <NavnOgIdent
+                            navn={fagsakEier.navn}
+                            ident={formaterFødselsnummer(fagsakEier.personIdent)}
+                        />
+                    </HStack>
                     <PersonopplysningerVarsler personopplysninger={fagsakEier} />
                     {skalViseSøker && (
                         <>
@@ -54,7 +55,7 @@ export function Visittkort({ behandling }: Props) {
                     )}
                 </HStack>
                 <LenkerOgKnapper behandling={behandling} />
-            </HStack>
-        </div>
+            </HGrid>
+        </Box>
     );
 }

--- a/src/frontend/Felles/Visittkort/Visittkort.tsx
+++ b/src/frontend/Felles/Visittkort/Visittkort.tsx
@@ -3,7 +3,7 @@ import styles from './Visittkort.module.css';
 import { Behandling } from '../../App/typer/fagsak';
 import { HStack } from '@navikt/ds-react';
 import { IkonVelger } from '../IkonVelger/IkonVelger';
-import { formaterOrgNummer, Institusjon } from '../../App/typer/institusjon';
+import { formaterOrgNummer } from '../../App/typer/institusjon';
 import { usePersonopplysningerContext } from '../../App/context/PersonopplysningerContext';
 import { LenkerOgKnapper } from './LenkerOgKnapper';
 import { PersonopplysningerVarsler } from './PersonopplysningerVarsler';
@@ -20,55 +20,31 @@ export function Visittkort({ behandling }: Props) {
     return (
         <div className={styles.container}>
             <HStack justify={'space-between'} width={'100%'}>
-                <VisittkortInner
-                    alder={20}
-                    ident={fagsakEier.personIdent}
-                    kjønn={fagsakEier.kjønn}
-                    navn={fagsakEier.navn}
-                    institusjon={behandling.institusjon}
-                >
+                <HStack align={'center'} gap={'space-8'} padding={'space-8'}>
+                    <IkonVelger
+                        alder={20}
+                        kjønn={fagsakEier.kjønn}
+                        width={24}
+                        height={24}
+                        institusjon={behandling.institusjon}
+                    />
+                    <NavnOgIdent
+                        navn={fagsakEier.navn}
+                        ident={formaterFødselsnummer(fagsakEier.personIdent)}
+                    />
                     <PersonopplysningerVarsler personopplysninger={fagsakEier} />
-                </VisittkortInner>
+                    {behandling.institusjon && (
+                        <>
+                            <div>|</div>
+                            <NavnOgIdent
+                                navn={`Søker: ${behandling.institusjon.navn}`}
+                                ident={formaterOrgNummer(behandling.institusjon.orgNummer)}
+                            />
+                        </>
+                    )}
+                </HStack>
                 <LenkerOgKnapper behandling={behandling} />
             </HStack>
         </div>
     );
 }
-
-export interface IProps extends React.PropsWithChildren {
-    alder: number;
-    ident: string;
-    kjønn: Kjønn;
-    navn: string;
-    institusjon?: Institusjon;
-}
-
-enum Kjønn {
-    KVINNE = 'KVINNE',
-    MANN = 'MANN',
-    UKJENT = 'UKJENT',
-}
-
-const VisittkortInner: React.FunctionComponent<IProps> = ({
-    alder,
-    children,
-    ident,
-    kjønn,
-    navn,
-    institusjon,
-}) => (
-    <HStack align={'center'} gap={'space-8'} padding={'space-8'}>
-        <IkonVelger alder={alder} kjønn={kjønn} width={24} height={24} institusjon={institusjon} />
-        <NavnOgIdent navn={navn} ident={formaterFødselsnummer(ident)} alder={alder} />
-        {institusjon && (
-            <>
-                <div>|</div>
-                <NavnOgIdent
-                    navn={`Søker: ${institusjon.navn}`}
-                    ident={formaterOrgNummer(institusjon.orgNummer)}
-                />
-            </>
-        )}
-        {children}
-    </HStack>
-);

--- a/src/frontend/Felles/Visittkort/Visittkort.tsx
+++ b/src/frontend/Felles/Visittkort/Visittkort.tsx
@@ -1,39 +1,21 @@
 import React from 'react';
 import styles from './Visittkort.module.css';
-import {
-    Behandling,
-    Klagebehandlingsårsak,
-    klagebehandlingsårsakTilTekst,
-    PåklagetVedtakstype,
-} from '../../App/typer/fagsak';
-import { HenleggKnapp } from './HenleggKnapp';
-import { BodyShort, CopyButton, HStack, Label, Link, Stack } from '@navikt/ds-react';
+import { Behandling } from '../../App/typer/fagsak';
+import { BodyShort, CopyButton, HStack, Label } from '@navikt/ds-react';
 import { PersonStatusVarsel } from '../Varsel/PersonStatusVarsel';
 import { AdressebeskyttelseVarsel } from '../Varsel/AdressebeskyttelseVarsel';
-import { EtikettFokus, EtikettInfo, EtikettSuksess } from '../Varsel/Etikett';
+import { EtikettFokus } from '../Varsel/Etikett';
 import { erEtterDagensDato } from '../../App/utils/dato';
-import { stønadstypeTilTekst } from '../../App/typer/stønadstype';
-import { ExternalLinkIcon } from '@navikt/aksel-icons';
-import {
-    utledBehandlingLenke,
-    utledSaksoversiktLenke,
-    utledTilbakekrevingLenke,
-} from '../../App/utils/utils';
-import { useApp } from '../../App/context/AppContext';
-import { FagsystemType } from '../../Komponenter/Behandling/Formkrav/typer';
-import { SettPåVentKnapp } from './SettPåVentKnapp';
-import { EndreBehandlendeEnhetKnapp } from './EndreBehandlendeEnhetKnapp';
 import { IkonVelger } from '../IkonVelger/IkonVelger';
 import { formaterOrgNummer, Institusjon } from '../../App/typer/institusjon';
 import { usePersonopplysningerContext } from '../../App/context/PersonopplysningerContext';
+import { LenkerOgKnapper } from './LenkerOgKnapper';
 
 interface Props {
     behandling: Behandling;
 }
 
 export function Visittkort({ behandling }: Props) {
-    const { appEnv } = useApp();
-
     const {
         fagsakEier: {
             personIdent,
@@ -46,16 +28,6 @@ export function Visittkort({ behandling }: Props) {
             vergemål,
         },
     } = usePersonopplysningerContext();
-
-    const skalLenkeTilFagsystemBehandling =
-        behandling.påklagetVedtak.påklagetVedtakstype === PåklagetVedtakstype.VEDTAK &&
-        behandling.påklagetVedtak.fagsystemVedtak?.fagsystemType === FagsystemType.ORDNIÆR;
-    const skalLenkeTilTilbakekreving =
-        behandling.påklagetVedtak.påklagetVedtakstype === PåklagetVedtakstype.VEDTAK &&
-        behandling.påklagetVedtak.fagsystemVedtak?.fagsystemType === FagsystemType.TILBAKEKREVING;
-    const behandlingLenke = utledBehandlingLenke(behandling, appEnv.eksternlenker);
-    const saksoversiktLenke = utledSaksoversiktLenke(behandling, appEnv.eksternlenker);
-    const tilbakekrevingLenke = utledTilbakekrevingLenke(behandling, appEnv.eksternlenker);
 
     return (
         <div className={styles.container}>
@@ -103,48 +75,7 @@ export function Visittkort({ behandling }: Props) {
                         </div>
                     )}
                 </VisittkortInner>
-                <HStack align={'center'} justify={'start'} gap={'space-8'} padding={'space-8'}>
-                    {skalLenkeTilFagsystemBehandling && (
-                        <Link href={behandlingLenke} target="_blank">
-                            Gå til behandling
-                            <ExternalLinkIcon
-                                aria-label="Gå til behandling"
-                                fontSize={'1.375rem'}
-                            />
-                        </Link>
-                    )}
-                    {skalLenkeTilTilbakekreving && (
-                        <Link href={tilbakekrevingLenke} target="_blank">
-                            Gå til tilbakekreving
-                            <ExternalLinkIcon
-                                aria-label="Gå til tilbakekreving"
-                                fontSize={'1.375rem'}
-                            />
-                        </Link>
-                    )}
-                    <Link href={saksoversiktLenke} target="_blank">
-                        Gå til saksoversikt
-                        <ExternalLinkIcon aria-label="Gå til saksoversikt" fontSize={'1.375rem'} />
-                    </Link>
-                    {behandling && (
-                        <Stack direction={'row'} gap={'space-8'}>
-                            <HStack justify={'end'} gap={'space-8'}>
-                                <EtikettSuksess>
-                                    {stønadstypeTilTekst[behandling.stønadstype]}
-                                </EtikettSuksess>
-                                {behandling.årsak ===
-                                    Klagebehandlingsårsak.HENVENDELSE_FRA_KABAL && (
-                                    <EtikettInfo>
-                                        {klagebehandlingsårsakTilTekst[behandling.årsak]}
-                                    </EtikettInfo>
-                                )}
-                            </HStack>
-                            <SettPåVentKnapp />
-                            <EndreBehandlendeEnhetKnapp fagsystem={behandling.fagsystem} />
-                            <HenleggKnapp />
-                        </Stack>
-                    )}
-                </HStack>
+                <LenkerOgKnapper behandling={behandling} />
             </HStack>
         </div>
     );

--- a/src/frontend/Felles/Visittkort/Visittkort.tsx
+++ b/src/frontend/Felles/Visittkort/Visittkort.tsx
@@ -24,8 +24,8 @@ export function Visittkort({ behandling }: Props) {
                 <HStack align={'center'} gap={'space-8 space-12'}>
                     <HStack align={'center'} gap={'space-8 space-12'} wrap={false}>
                         <IkonVelger
-                            alder={nullableDatoTilAlder(fagsakEier.fødselsdato) || 18}
                             kjønn={fagsakEier.kjønn}
+                            alder={nullableDatoTilAlder(fagsakEier.fødselsdato)}
                             institusjon={behandling.institusjon}
                         />
                         <NavnOgIdent

--- a/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
@@ -14,16 +14,20 @@ import { SettPåVent } from './SettPåVent/SettPåVent';
 import { EndreBehandlendeEnhetModal } from './EndreBehandlendeEnhet/EndreBehandlendeEnhetModal';
 import { HenleggBehandlingModal } from './Henleggelse/HenleggBehandlingModal';
 import { PersonopplysningerContextProvider } from '../../App/context/PersonopplysningerContext';
+import { useParams } from 'react-router-dom';
 
 interface Props {
     behandling: Behandling;
 }
 
-export const BehandlingContainer: FC = () => (
-    <BehandlingProvider>
-        <BehandlingOverbygg />
-    </BehandlingProvider>
-);
+export const BehandlingContainer: FC = () => {
+    const behandlingId = useParams<{ behandlingId: string }>().behandlingId as string;
+    return (
+        <BehandlingProvider key={behandlingId}>
+            <BehandlingOverbygg />
+        </BehandlingProvider>
+    );
+};
 
 const BehandlingOverbygg: FC = () => {
     const { personopplysningerResponse, behandling } = useBehandling();

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/LandFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/LandFelt.tsx
@@ -20,7 +20,9 @@ export function LandFelt({ erLesevisning = false }: Props) {
     const { control, getValues, setValue, resetField } =
         useFormContext<BrevmottakerPersonUtenIdentFormValues>();
 
-    const { navn } = usePersonopplysningerContext();
+    const {
+        fagsakEier: { navn },
+    } = usePersonopplysningerContext();
 
     const { field, fieldState, formState } = useController({
         name: BrevmottakerPersonUtenIdentFeltnavn.LANDKODE,

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/MottakerFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/modal/form/felt/MottakerFelt.tsx
@@ -26,7 +26,9 @@ export function MottakerFelt({ valgteMottakerRoller, erLesevisning = false }: Pr
     const { control, setValue, getValues, resetField } =
         useFormContext<BrevmottakerPersonUtenIdentFormValues>();
 
-    const { navn } = usePersonopplysningerContext();
+    const {
+        fagsakEier: { navn },
+    } = usePersonopplysningerContext();
 
     const { field, fieldState, formState } = useController({
         name: BrevmottakerPersonUtenIdentFeltnavn.MOTTAKERROLLE,

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/panel/BrevmottakerPanel.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/panel/BrevmottakerPanel.tsx
@@ -25,7 +25,7 @@ export function BrevmottakerPanel({ brevmottakere }: Props) {
     const kanEndreBrevmottakere =
         behandlingErRedigerbar &&
         (fagsakEierPersonIdent == søkerPersonIdent ||
-            !toggles[ToggleName.BRUK_SØKER_PERSONOPPLYSNINGER]);
+            toggles[ToggleName.BRUK_SØKER_PERSONOPPLYSNINGER] == false);
 
     return (
         <>

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/panel/BrevmottakerPanel.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/panel/BrevmottakerPanel.tsx
@@ -4,6 +4,9 @@ import { useBehandling } from '../../../../../App/context/BehandlingContext';
 import { BodyShort, Box, Button, HStack, Label, Tooltip } from '@navikt/ds-react';
 import { utledOppsumertBrevmottakere } from '../oppsummertBrevmottaker';
 import { Brevmottakere } from '../../brevmottakere';
+import { useToggles } from '../../../../../App/context/TogglesContext';
+import { usePersonopplysningerContext } from '../../../../../App/context/PersonopplysningerContext';
+import { ToggleName } from '../../../../../App/context/toggles';
 
 type Props = {
     brevmottakere: Brevmottakere;
@@ -12,15 +15,24 @@ type Props = {
 export function BrevmottakerPanel({ brevmottakere }: Props) {
     const { settVisBrevmottakereModal } = useApp();
     const { behandlingErRedigerbar } = useBehandling();
+    const {
+        fagsakEier: { personIdent: fagsakEierPersonIdent },
+        søker: { personIdent: søkerPersonIdent },
+    } = usePersonopplysningerContext();
+    const { toggles } = useToggles();
 
     const oppsumertBrevmottakere = utledOppsumertBrevmottakere(brevmottakere);
+    const kanEndreBrevmottakere =
+        behandlingErRedigerbar &&
+        (fagsakEierPersonIdent == søkerPersonIdent ||
+            !toggles[ToggleName.BRUK_SØKER_PERSONOPPLYSNINGER]);
 
     return (
         <>
             <Box background={'surface-info-subtle'} padding={'6'}>
                 <HStack justify={'space-between'} align={'center'}>
                     <Label htmlFor={'brevmottakere_liste'}>Brevmottakere</Label>
-                    {behandlingErRedigerbar && (
+                    {kanEndreBrevmottakere && (
                         <Tooltip content={'Legg til eller fjern brevmottakere'}>
                             <Button
                                 variant={'tertiary'}

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/baks/panel/BrevmottakerPanel.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/baks/panel/BrevmottakerPanel.tsx
@@ -24,8 +24,8 @@ export function BrevmottakerPanel({ brevmottakere }: Props) {
     const oppsumertBrevmottakere = utledOppsumertBrevmottakere(brevmottakere);
     const kanEndreBrevmottakere =
         behandlingErRedigerbar &&
-        (fagsakEierPersonIdent == søkerPersonIdent ||
-            toggles[ToggleName.BRUK_SØKER_PERSONOPPLYSNINGER] == false);
+        (fagsakEierPersonIdent === søkerPersonIdent ||
+            toggles[ToggleName.BRUK_SØKER_PERSONOPPLYSNINGER] === false);
 
     return (
         <>

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/ef/SkalBrukerHaBrev.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/ef/SkalBrukerHaBrev.tsx
@@ -10,7 +10,9 @@ interface Props {
 }
 
 export const SkalBrukerHaBrev: FC<Props> = ({ valgteBrevmottakere, settValgtBrevMottakere }) => {
-    const { navn, personIdent } = usePersonopplysningerContext();
+    const {
+        fagsakEier: { navn, personIdent },
+    } = usePersonopplysningerContext();
     const brukerSkalHaBrev = valgteBrevmottakere.some(
         (mottaker) => mottaker.mottakerRolle === MottakerRolle.BRUKER
     );

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/ef/VergerOgFullmektigeFraRegister.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/ef/VergerOgFullmektigeFraRegister.tsx
@@ -21,7 +21,9 @@ export const VergerOgFullmektigeFraRegister: FC<Props> = ({
     valgteMottakere,
     settValgteMottakere,
 }) => {
-    const { vergemål, fullmakt } = usePersonopplysningerContext();
+    const {
+        fagsakEier: { vergemål, fullmakt },
+    } = usePersonopplysningerContext();
 
     const muligeMottakere = [
         ...vergemål.map(mapVergemålTilBrevmottakerPersonMedIdent),

--- a/src/frontend/Komponenter/Behandling/Henleggelse/BrevmottakereBox.tsx
+++ b/src/frontend/Komponenter/Behandling/Henleggelse/BrevmottakereBox.tsx
@@ -9,22 +9,35 @@ import { BrevmottakerDetaljer } from './BrevmottakerDetaljer';
 import { useBrevmottakereContext } from './context/BrevmottakereContextProvider';
 import { useBrevmottakerFormActionsContext } from './context/BrevmottakerFormActionsContextProvider';
 import { Behandling, Fagsystem } from '../../../App/typer/fagsak';
+import { useToggles } from '../../../App/context/TogglesContext';
+import { usePersonopplysningerContext } from '../../../App/context/PersonopplysningerContext';
+import { ToggleName } from '../../../App/context/toggles';
+import { useBehandling } from '../../../App/context/BehandlingContext';
 
 interface Props {
     behandling: Behandling;
 }
 
 export function BrevmottakereBox({ behandling }: Props) {
+    const { behandlingErRedigerbar } = useBehandling();
     const { brevmottakere } = useBrevmottakereContext();
     const { visForm } = useBrevmottakerFormActionsContext();
+    const {
+        fagsakEier: { personIdent: fagsakEierPersonIdent },
+        søker: { personIdent: søkerPersonIdent },
+    } = usePersonopplysningerContext();
+    const { toggles } = useToggles();
 
     const harDødsboBrevmottaker = harEnDødsboNyBrevmottaker(brevmottakere);
     const harBruker = harEnBrukerNyBrevmottaker(brevmottakere);
 
     const visLeggTilNyBrevmottakerKnapp =
+        behandlingErRedigerbar &&
         behandling.fagsystem !== Fagsystem.EF &&
         !harDødsboBrevmottaker &&
-        (brevmottakere.length < 2 || harBruker);
+        (brevmottakere.length < 2 || harBruker) &&
+        (fagsakEierPersonIdent == søkerPersonIdent ||
+            !toggles[ToggleName.BRUK_SØKER_PERSONOPPLYSNINGER]);
 
     return (
         <Box as={'div'} background={'surface-neutral-subtle'} padding={'space-12'}>

--- a/src/frontend/Komponenter/Behandling/Henleggelse/BrevmottakereBox.tsx
+++ b/src/frontend/Komponenter/Behandling/Henleggelse/BrevmottakereBox.tsx
@@ -36,8 +36,8 @@ export function BrevmottakereBox({ behandling }: Props) {
         behandling.fagsystem !== Fagsystem.EF &&
         !harDødsboBrevmottaker &&
         (brevmottakere.length < 2 || harBruker) &&
-        (fagsakEierPersonIdent == søkerPersonIdent ||
-            toggles[ToggleName.BRUK_SØKER_PERSONOPPLYSNINGER] == false);
+        (fagsakEierPersonIdent === søkerPersonIdent ||
+            toggles[ToggleName.BRUK_SØKER_PERSONOPPLYSNINGER] === false);
 
     return (
         <Box as={'div'} background={'surface-neutral-subtle'} padding={'space-12'}>

--- a/src/frontend/Komponenter/Behandling/Henleggelse/BrevmottakereBox.tsx
+++ b/src/frontend/Komponenter/Behandling/Henleggelse/BrevmottakereBox.tsx
@@ -37,7 +37,7 @@ export function BrevmottakereBox({ behandling }: Props) {
         !harDødsboBrevmottaker &&
         (brevmottakere.length < 2 || harBruker) &&
         (fagsakEierPersonIdent == søkerPersonIdent ||
-            !toggles[ToggleName.BRUK_SØKER_PERSONOPPLYSNINGER]);
+            toggles[ToggleName.BRUK_SØKER_PERSONOPPLYSNINGER] == false);
 
     return (
         <Box as={'div'} background={'surface-neutral-subtle'} padding={'space-12'}>

--- a/src/frontend/Komponenter/Behandling/Henleggelse/HenleggBehandlingForm.tsx
+++ b/src/frontend/Komponenter/Behandling/Henleggelse/HenleggBehandlingForm.tsx
@@ -61,9 +61,9 @@ export function HenleggBehandlingForm({ form, onSubmit, fagsystem }: Props) {
     const henlagtÅrsak = watch(HenleggBehandlingFeltnavn.HENLAGT_ÅRSAK);
 
     const erHenlagtÅrsakTrukketTilbakeValgt = erHenlagtÅrsakTrukketTilbake(henlagtÅrsak);
-    const personopplysninger = usePersonopplysningerContext();
-    const erTilknyttetFullmakt = erPersonopplysningerTilknyttetFullmakt(personopplysninger);
-    const harVergemål = harPersonopplysningerVergemål(personopplysninger);
+    const { fagsakEier } = usePersonopplysningerContext();
+    const erTilknyttetFullmakt = erPersonopplysningerTilknyttetFullmakt(fagsakEier);
+    const harVergemål = harPersonopplysningerVergemål(fagsakEier);
 
     const erMuligÅSendeBrev =
         (fagsystem !== Fagsystem.EF || (!harVergemål && !erTilknyttetFullmakt)) &&

--- a/src/frontend/Komponenter/Behandling/Henleggelse/SendManueltBrevAdvarsel.tsx
+++ b/src/frontend/Komponenter/Behandling/Henleggelse/SendManueltBrevAdvarsel.tsx
@@ -7,9 +7,9 @@ import {
 import { usePersonopplysningerContext } from '../../../App/context/PersonopplysningerContext';
 
 export function SendManueltBrevAdvarsel() {
-    const personopplysninger = usePersonopplysningerContext();
-    const erTilknyttetFullmakt = erPersonopplysningerTilknyttetFullmakt(personopplysninger);
-    const harVergemål = harPersonopplysningerVergemål(personopplysninger);
+    const { fagsakEier } = usePersonopplysningerContext();
+    const erTilknyttetFullmakt = erPersonopplysningerTilknyttetFullmakt(fagsakEier);
+    const harVergemål = harPersonopplysningerVergemål(fagsakEier);
 
     return (
         <>


### PR DESCRIPTION
Favro: NAV-27967

Les commit for commit

Må merges etter backend

- Henter personopplysninger for fagsakeier og søker fra backend
- Splitter opp komponentene i `Visittkort`
- Viser søker i `VIsittkort`
- Endrer stylingen av `Visittkort`, så komponentene plasseres bedre på små skjermer
- Fjerner muligheten for å legge til manuelle brevmottakere i skjermet barn-fagsaker

### Før
<img width="1172" height="83" alt="79e9df6686100fc7844e9ce591410214" src="https://github.com/user-attachments/assets/a1e40402-860f-4590-a752-04a14b17d1c4" />
<img width="745" height="81" alt="ddbcc98802de7da96e33abfc437b7045" src="https://github.com/user-attachments/assets/081065b5-fec3-483e-a7c6-80bb94ec4b89" />

### Etter
<img width="2341" height="49" alt="e90ec8f3d98832dcf7a645fddb8f9a01" src="https://github.com/user-attachments/assets/4d0332af-e775-484a-87c5-7f47550ae31d" />
<img width="1946" height="70" alt="34e2241e06dbcd741113b04ea963a4e2" src="https://github.com/user-attachments/assets/1f627d52-081e-4fb4-8441-269de700dec7" />
<img width="1522" height="87" alt="bf2bc890d08003ea7fed97620531ec61" src="https://github.com/user-attachments/assets/d89c07a4-3a7f-469d-9f9b-a269c4f6d004" />
<img width="1191" height="113" alt="22c6b3b04c7a8c0d718fdeaf83347490" src="https://github.com/user-attachments/assets/63ef9c3b-1277-4411-b813-1f3b7a74588d" />
