### PR TITLE
Viser funksjonell feilmelding ved Ikke tilgang feil, og en advarsel om at man ikke har tilgang til fullmakt

### DIFF
--- a/src/frontend/App/typer/personopplysninger.ts
+++ b/src/frontend/App/typer/personopplysninger.ts
@@ -15,6 +15,7 @@ export interface IPersonopplysninger {
     fødselsdato?: string;
     egenAnsatt: boolean;
     fullmakt: IFullmakt[];
+    harFullmaktTilgang: boolean;
     navEnhet: string;
     vergemål: IVergemål[];
 }

--- a/src/frontend/Felles/DataViewer/DataViewer.tsx
+++ b/src/frontend/Felles/DataViewer/DataViewer.tsx
@@ -26,7 +26,8 @@ const renderFeil = (responses: Ressurs<any>[]) => (
         {responses.map((feilet, index) => {
             if (
                 feilet.status === RessursStatus.FUNKSJONELL_FEIL ||
-                feilet.status === RessursStatus.FEILET
+                feilet.status === RessursStatus.FEILET ||
+                feilet.status === RessursStatus.IKKE_TILGANG
             ) {
                 return (
                     <Alert className={styles.alert} key={index} variant={'error'}>
@@ -58,10 +59,15 @@ export const DataViewer = <T extends Record<string, unknown>>(
 ): ReactNode | null => {
     const { response, children } = props;
     const responses = Object.values(response);
-    if (harNoenRessursMedStatus(responses, RessursStatus.FUNKSJONELL_FEIL, RessursStatus.FEILET)) {
+    if (
+        harNoenRessursMedStatus(
+            responses,
+            RessursStatus.FUNKSJONELL_FEIL,
+            RessursStatus.FEILET,
+            RessursStatus.IKKE_TILGANG
+        )
+    ) {
         return renderFeil(responses);
-    } else if (harNoenRessursMedStatus(responses, RessursStatus.IKKE_TILGANG)) {
-        return <Alert variant={'error'}>Ikke tilgang!</Alert>;
     } else if (harNoenRessursMedStatus(responses, RessursStatus.HENTER)) {
         return (
             <VStack margin="space-16" align="center">

--- a/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
@@ -15,6 +15,8 @@ import { EndreBehandlendeEnhetModal } from './EndreBehandlendeEnhet/EndreBehandl
 import { HenleggBehandlingModal } from './Henleggelse/HenleggBehandlingModal';
 import { PersonopplysningerContextProvider } from '../../App/context/PersonopplysningerContext';
 import { useParams } from 'react-router-dom';
+import { usePersonopplysningerContext } from '../../App/context/PersonopplysningerContext';
+import { Alert } from '@navikt/ds-react';
 
 interface Props {
     behandling: Behandling;
@@ -49,6 +51,7 @@ const BehandlingOverbygg: FC = () => {
 
 const BehandlingContent: FC<Props> = ({ behandling }) => {
     const { åpenHøyremeny } = useBehandling();
+    const { fagsakEier } = usePersonopplysningerContext();
 
     useSetValgtFagsakId(behandling.fagsakId);
 
@@ -67,6 +70,11 @@ const BehandlingContent: FC<Props> = ({ behandling }) => {
             <div className={styles.container}>
                 <div className={classNameBehandlingContainer} id="scroll-topp">
                     <Fanemeny behandling={behandling} />
+                    {!fagsakEier.harFullmaktTilgang && (
+                        <Alert variant={'warning'} style={{ marginBottom: '1rem' }}>
+                            Har ikke tilgang til å hente fullmaktopplysninger for denne personen.
+                        </Alert>
+                    )}
                     <SettPåVent behandling={behandling} />
                     <EndreBehandlendeEnhetModal behandling={behandling} />
                     <BehandlingRoutes behandling={behandling} />


### PR DESCRIPTION
- Endepunkt /fagsak-og-eier henter inn fullmakt. Hvis man ikke har tilgang til fullmakt, så får man ikke lastet inn behandlingen. Det er typisk vi utviklere som ikke har tilgang. Viser heretter en advarsel om når backend ikke har kunne legge til fullmakter på endepunktet. Avhenger av https://github.com/navikt/familie-klage/pull/847

<img width="1042" height="288" alt="image" src="https://github.com/user-attachments/assets/10d2aa8e-f090-4ca9-91fb-a85d444336d6" />. 




- I stedet for å vise en generll Ikke tilgang for andre tilgangsproblemer, så viser man den funksjonelle feilmeldingen
Før:
<img width="337" height="234" alt="image" src="https://github.com/user-attachments/assets/42258c51-480e-4dac-ba2e-270d2db6b9fe" />


Etter:
<img width="348" height="345" alt="image" src="https://github.com/user-attachments/assets/44b6973c-1d5c-432f-928b-afee996bfde1" />


